### PR TITLE
fix(accounts): auto-create profile with signals and update tests

### DIFF
--- a/backend/apps/accounts/apps.py
+++ b/backend/apps/accounts/apps.py
@@ -2,5 +2,8 @@ from django.apps import AppConfig
 
 
 class AccountsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'apps.accounts'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.accounts"
+
+    def ready(self):
+        import apps.accounts.signals  # noqa: F401

--- a/backend/apps/accounts/serializers.py
+++ b/backend/apps/accounts/serializers.py
@@ -8,6 +8,8 @@ from apps.buildings.models import Edifici, Habitatge
 from django.contrib.auth import authenticate
 from rest_framework_simplejwt.tokens import RefreshToken
 
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError as DjangoValidationError
 
 User = get_user_model()
 
@@ -28,19 +30,38 @@ class RegisterSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         if attrs["password"] != attrs["password_confirm"]:
-            raise serializers.ValidationError({"password_confirm": "Les contrasenyes no coincideixen."})
+            raise serializers.ValidationError(
+                {"password_confirm": "Les contrasenyes no coincideixen."}
+            )
 
         requested_role = attrs.get("role")
         if requested_role == RoleChoices.ADMIN:
-            raise serializers.ValidationError({"role": "No està permès registrar-se com a administrador."})
+            raise serializers.ValidationError(
+                {"role": "No està permès registrar-se com a administrador."}
+            )
 
         password = attrs["password"]
 
         if not any(char.isalpha() for char in password):
-            raise serializers.ValidationError({"password": "La contrasenya ha de contenir almenys una lletra."})
+            raise serializers.ValidationError(
+                {"password": "La contrasenya ha de contenir almenys una lletra."}
+            )
 
         if not any(char.isdigit() for char in password):
-            raise serializers.ValidationError({"password": "La contrasenya ha de contenir almenys un número."})
+            raise serializers.ValidationError(
+                {"password": "La contrasenya ha de contenir almenys un número."}
+            )
+
+        temp_user = User(
+            email=attrs.get("email", ""),
+            first_name=attrs.get("first_name", ""),
+            last_name=attrs.get("last_name", ""),
+        )
+
+        try:
+            validate_password(password, user=temp_user)
+        except DjangoValidationError as exc:
+            raise serializers.ValidationError({"password": list(exc.messages)})
 
         return attrs
 
@@ -56,7 +77,9 @@ class RegisterSerializer(serializers.ModelSerializer):
             **validated_data,
         )
 
-        Profile.objects.create(user=user, role=role)
+        profile, _ = Profile.objects.get_or_create(user=user)
+        profile.role = role
+        profile.save(update_fields=["role"])
 
         return user
     

--- a/backend/apps/accounts/signals.py
+++ b/backend/apps/accounts/signals.py
@@ -1,0 +1,10 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from apps.accounts.models import Profile, User
+
+
+@receiver(post_save, sender=User)
+def create_user_profile(sender, instance, created, **kwargs):
+    if created:
+        Profile.objects.get_or_create(user=instance)

--- a/backend/apps/accounts/tests.py
+++ b/backend/apps/accounts/tests.py
@@ -16,341 +16,342 @@ from apps.buildings.models import (
 )
 
 class BaseTestData(APITestCase):
-	"""Base class with shared test data creation utilities."""
+    """Base class with shared test data creation utilities."""
 
-	@classmethod
-	def _create_user(cls, email, role):
-		"""Create a user with given email and role."""
-		user = User.objects.create_user(
-			email=email,
-			password="Password123",
-			first_name=email.split("@")[0],
-		)
-		Profile.objects.create(user=user, role=role)
-		return user
+    @classmethod
+    def _create_user(cls, email, role):
+        """Create a user with given email and role."""
+        user = User.objects.create_user(
+            email=email,
+            password="Password123",
+            first_name=email.split("@")[0],
+        )
+        user.profile.role = role
+        user.profile.save(update_fields=["role"])
+        return user
 
-	@classmethod
-	def _create_edifici(cls, identificador, administrador, grup):
-		"""Create a building with location and group."""
-		localitzacio = Localitzacio.objects.create(
-			carrer=f"Carrer {identificador}",
-			numero=1,
-			codiPostal="08001",
-			barri="Centre",
-			latitud=41.0,
-			longitud=2.0,
-			zonaClimatica="C2",
-		)
-		return Edifici.objects.create(
-			idEdifici=identificador,
-			anyConstruccio=2000,
-			tipologia="Residencial",
-			superficieTotal=400,
-			reglament="CTE",
-			orientacioPrincipal="Sud",
-			puntuacioBase=75,
-			localitzacio=localitzacio,
-			administradorFinca=administrador,
-			grupComparable=grup,
-		)
+    @classmethod
+    def _create_edifici(cls, identificador, administrador, grup):
+        """Create a building with location and group."""
+        localitzacio = Localitzacio.objects.create(
+            carrer=f"Carrer {identificador}",
+            numero=1,
+            codiPostal="08001",
+            barri="Centre",
+            latitud=41.0,
+            longitud=2.0,
+            zonaClimatica="C2",
+        )
+        return Edifici.objects.create(
+            idEdifici=identificador,
+            anyConstruccio=2000,
+            tipologia="Residencial",
+            superficieTotal=400,
+            reglament="CTE",
+            orientacioPrincipal="Sud",
+            puntuacioBase=75,
+            localitzacio=localitzacio,
+            administradorFinca=administrador,
+            grupComparable=grup,
+        )
 
 
 class RBACAuthorizationTests(BaseTestData):
-	"""Role-Based Access Control authorization tests."""
+    """Role-Based Access Control authorization tests."""
 
-	@classmethod
-	def setUpTestData(cls):
-		"""Set up test data once for all tests in this class."""
-		cls.admin = cls._create_user("admin@example.com", RoleChoices.ADMIN)
-		cls.admin_finca = cls._create_user("owner@example.com", RoleChoices.OWNER)
-		cls.altre_admin_finca = cls._create_user("owner2@example.com", RoleChoices.OWNER)
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data once for all tests in this class."""
+        cls.admin = cls._create_user("admin@example.com", RoleChoices.ADMIN)
+        cls.admin_finca = cls._create_user("owner@example.com", RoleChoices.OWNER)
+        cls.altre_admin_finca = cls._create_user("owner2@example.com", RoleChoices.OWNER)
 
-		cls.grup = GrupComparable.objects.create(
-			idGrup=1,
-			zonaClimatica="C2",
-			tipologia="Residencial",
-			rangSuperficie="100-200",
-		)
+        cls.grup = GrupComparable.objects.create(
+            idGrup=1,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="100-200",
+        )
 
-		cls.edifici_1 = cls._create_edifici("EDI-1", administrador=cls.admin_finca, grup=cls.grup)
+        cls.edifici_1 = cls._create_edifici("EDI-1", administrador=cls.admin_finca, grup=cls.grup)
 
-	def test_admin_sistema_can_assign_admin_to_building(self):
-		"""AdminSistema has permission to assign admin to any building."""
-		self.client.force_authenticate(user=self.admin)
+    def test_admin_sistema_can_assign_admin_to_building(self):
+        """AdminSistema has permission to assign admin to any building."""
+        self.client.force_authenticate(user=self.admin)
 
-		response = self.client.patch(
-			reverse("assignar-admin-edifici", args=[self.edifici_1.idEdifici]),
-			{"user_id": self.altre_admin_finca.id},
-			format="json",
-		)
+        response = self.client.patch(
+            reverse("assignar-admin-edifici", args=[self.edifici_1.idEdifici]),
+            {"user_id": self.altre_admin_finca.id},
+            format="json",
+        )
 
-		self.assertEqual(response.status_code, status.HTTP_200_OK)
-		self.edifici_1.refresh_from_db()
-		self.assertEqual(self.edifici_1.administradorFinca_id, self.altre_admin_finca.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.edifici_1.refresh_from_db()
+        self.assertEqual(self.edifici_1.administradorFinca_id, self.altre_admin_finca.id)
 
-	def test_admin_finca_cannot_assign_admin_to_building(self):
-		"""AdminFinca (owner) lacks permission to assign admin."""
-		self.client.force_authenticate(user=self.admin_finca)
+    def test_admin_finca_cannot_assign_admin_to_building(self):
+        """AdminFinca (owner) lacks permission to assign admin."""
+        self.client.force_authenticate(user=self.admin_finca)
 
-		response = self.client.patch(
-			reverse("assignar-admin-edifici", args=[self.edifici_1.idEdifici]),
-			{"user_id": self.altre_admin_finca.id},
-			format="json",
-		)
+        response = self.client.patch(
+            reverse("assignar-admin-edifici", args=[self.edifici_1.idEdifici]),
+            {"user_id": self.altre_admin_finca.id},
+            format="json",
+        )
 
-		self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-	def test_unauthenticated_user_cannot_assign_admin(self):
-		"""Unauthenticated requests must return 401."""
-		response = self.client.patch(
-			reverse("assignar-admin-edifici", args=[self.edifici_1.idEdifici]),
-			{"user_id": self.altre_admin_finca.id},
-			format="json",
-		)
+    def test_unauthenticated_user_cannot_assign_admin(self):
+        """Unauthenticated requests must return 401."""
+        response = self.client.patch(
+            reverse("assignar-admin-edifici", args=[self.edifici_1.idEdifici]),
+            {"user_id": self.altre_admin_finca.id},
+            format="json",
+        )
 
-		self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class ABACTests(BaseTestData):
-	"""Attribute-Based Access Control authorization tests."""
+    """Attribute-Based Access Control authorization tests."""
 
-	@classmethod
-	def setUpTestData(cls):
-		"""Set up buildings with different admins for ABAC testing."""
-		cls.admin_finca = cls._create_user("owner@example.com", RoleChoices.OWNER)
-		cls.altre_admin_finca = cls._create_user("owner2@example.com", RoleChoices.OWNER)
-		cls.resident = cls._create_user("tenant@example.com", RoleChoices.TENANT)
+    @classmethod
+    def setUpTestData(cls):
+        """Set up buildings with different admins for ABAC testing."""
+        cls.admin_finca = cls._create_user("owner@example.com", RoleChoices.OWNER)
+        cls.altre_admin_finca = cls._create_user("owner2@example.com", RoleChoices.OWNER)
+        cls.resident = cls._create_user("tenant@example.com", RoleChoices.TENANT)
 
-		cls.grup = GrupComparable.objects.create(
-			idGrup=1,
-			zonaClimatica="C2",
-			tipologia="Residencial",
-			rangSuperficie="100-200",
-		)
+        cls.grup = GrupComparable.objects.create(
+            idGrup=1,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="100-200",
+        )
 
-		cls.edifici_1 = cls._create_edifici("EDI-1", administrador=cls.admin_finca, grup=cls.grup)
-		cls.edifici_2 = cls._create_edifici("EDI-2", administrador=cls.altre_admin_finca, grup=cls.grup)
+        cls.edifici_1 = cls._create_edifici("EDI-1", administrador=cls.admin_finca, grup=cls.grup)
+        cls.edifici_2 = cls._create_edifici("EDI-2", administrador=cls.altre_admin_finca, grup=cls.grup)
 
-		cls.habitatge_1 = Habitatge.objects.create(
-			referenciaCadastral="HAB-1",
-			planta="1",
-			porta="A",
-			superficie=80,
-			edifici=cls.edifici_1,
-			usuari=cls.resident,
-		)
-		cls.habitatge_2 = Habitatge.objects.create(
-			referenciaCadastral="HAB-2",
-			planta="2",
-			porta="B",
-			superficie=95,
-			edifici=cls.edifici_2,
-			usuari=cls.resident,
-		)
+        cls.habitatge_1 = Habitatge.objects.create(
+            referenciaCadastral="HAB-1",
+            planta="1",
+            porta="A",
+            superficie=80,
+            edifici=cls.edifici_1,
+            usuari=cls.resident,
+        )
+        cls.habitatge_2 = Habitatge.objects.create(
+            referenciaCadastral="HAB-2",
+            planta="2",
+            porta="B",
+            superficie=95,
+            edifici=cls.edifici_2,
+            usuari=cls.resident,
+        )
 
-	def test_admin_finca_gets_403_on_idor_for_unmanaged_building(self):
-		"""IDOR attack: AdminFinca cannot access apartment in unmanaged building."""
-		self.client.force_authenticate(user=self.admin_finca)
+    def test_admin_finca_gets_403_on_idor_for_unmanaged_building(self):
+        """IDOR attack: AdminFinca cannot access apartment in unmanaged building."""
+        self.client.force_authenticate(user=self.admin_finca)
 
-		response = self.client.patch(
-			reverse("assignar-resident", args=[self.habitatge_2.referenciaCadastral]),
-			{"user_id": self.resident.id},
-			format="json",
-		)
+        response = self.client.patch(
+            reverse("assignar-resident", args=[self.habitatge_2.referenciaCadastral]),
+            {"user_id": self.resident.id},
+            format="json",
+        )
 
-		self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-		self.assertEqual(AccessDenialLog.objects.count(), 1)
-		denial = AccessDenialLog.objects.first()
-		self.assertEqual(denial.user_id, self.admin_finca.id)
-		self.assertIn("cartera de gestió", denial.motiu)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(AccessDenialLog.objects.count(), 1)
+        denial = AccessDenialLog.objects.first()
+        self.assertEqual(denial.user_id, self.admin_finca.id)
+        self.assertIn("cartera de gestió", denial.motiu)
 
 
 class AssignmentTests(BaseTestData):
-	"""Tests for resident assignment functionality."""
+    """Tests for resident assignment functionality."""
 
-	@classmethod
-	def setUpTestData(cls):
-		"""Set up buildings and residents for assignment testing."""
-		cls.admin_finca = cls._create_user("owner@example.com", RoleChoices.OWNER)
-		cls.resident = cls._create_user("tenant@example.com", RoleChoices.TENANT)
-		cls.altre_resident = cls._create_user("tenant2@example.com", RoleChoices.TENANT)
+    @classmethod
+    def setUpTestData(cls):
+        """Set up buildings and residents for assignment testing."""
+        cls.admin_finca = cls._create_user("owner@example.com", RoleChoices.OWNER)
+        cls.resident = cls._create_user("tenant@example.com", RoleChoices.TENANT)
+        cls.altre_resident = cls._create_user("tenant2@example.com", RoleChoices.TENANT)
 
-		cls.grup = GrupComparable.objects.create(
-			idGrup=1,
-			zonaClimatica="C2",
-			tipologia="Residencial",
-			rangSuperficie="100-200",
-		)
+        cls.grup = GrupComparable.objects.create(
+            idGrup=1,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="100-200",
+        )
 
-		cls.edifici_1 = cls._create_edifici("EDI-1", administrador=cls.admin_finca, grup=cls.grup)
+        cls.edifici_1 = cls._create_edifici("EDI-1", administrador=cls.admin_finca, grup=cls.grup)
 
-		cls.habitatge_1 = Habitatge.objects.create(
-			referenciaCadastral="HAB-1",
-			planta="1",
-			porta="A",
-			superficie=80,
-			edifici=cls.edifici_1,
-			usuari=cls.resident,
-		)
+        cls.habitatge_1 = Habitatge.objects.create(
+            referenciaCadastral="HAB-1",
+            planta="1",
+            porta="A",
+            superficie=80,
+            edifici=cls.edifici_1,
+            usuari=cls.resident,
+        )
 
-	def test_admin_finca_can_assign_resident_inside_managed_building(self):
-		"""AdminFinca can assign resident to apartment in managed building."""
-		self.client.force_authenticate(user=self.admin_finca)
+    def test_admin_finca_can_assign_resident_inside_managed_building(self):
+        """AdminFinca can assign resident to apartment in managed building."""
+        self.client.force_authenticate(user=self.admin_finca)
 
-		response = self.client.patch(
-			reverse("assignar-resident", args=[self.habitatge_1.referenciaCadastral]),
-			{"user_id": self.altre_resident.id},
-			format="json",
-		)
+        response = self.client.patch(
+            reverse("assignar-resident", args=[self.habitatge_1.referenciaCadastral]),
+            {"user_id": self.altre_resident.id},
+            format="json",
+        )
 
-		self.assertEqual(response.status_code, status.HTTP_200_OK)
-		self.habitatge_1.refresh_from_db()
-		self.assertEqual(self.habitatge_1.usuari_id, self.altre_resident.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.habitatge_1.refresh_from_db()
+        self.assertEqual(self.habitatge_1.usuari_id, self.altre_resident.id)
 
-	def test_tenant_cannot_assign_resident(self):
-		"""Tenant (resident) lacks permission to assign other residents."""
-		self.client.force_authenticate(user=self.resident)
+    def test_tenant_cannot_assign_resident(self):
+        """Tenant (resident) lacks permission to assign other residents."""
+        self.client.force_authenticate(user=self.resident)
 
-		response = self.client.patch(
-			reverse("assignar-resident", args=[self.habitatge_1.referenciaCadastral]),
-			{"user_id": self.altre_resident.id},
-			format="json",
-		)
+        response = self.client.patch(
+            reverse("assignar-resident", args=[self.habitatge_1.referenciaCadastral]),
+            {"user_id": self.altre_resident.id},
+            format="json",
+        )
 
-		self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class QueryTests(BaseTestData):
-	"""Tests for building query endpoint (GET /api/me/edificis/)."""
+    """Tests for building query endpoint (GET /api/me/edificis/)."""
 
-	@classmethod
-	def setUpTestData(cls):
-		"""Set up buildings and users with different roles."""
-		cls.admin = cls._create_user("admin@example.com", RoleChoices.ADMIN)
-		cls.admin_finca = cls._create_user("owner@example.com", RoleChoices.OWNER)
-		cls.altre_admin_finca = cls._create_user("owner2@example.com", RoleChoices.OWNER)
-		cls.resident = cls._create_user("tenant@example.com", RoleChoices.TENANT)
-		cls.altre_resident = cls._create_user("tenant2@example.com", RoleChoices.TENANT)
+    @classmethod
+    def setUpTestData(cls):
+        """Set up buildings and users with different roles."""
+        cls.admin = cls._create_user("admin@example.com", RoleChoices.ADMIN)
+        cls.admin_finca = cls._create_user("owner@example.com", RoleChoices.OWNER)
+        cls.altre_admin_finca = cls._create_user("owner2@example.com", RoleChoices.OWNER)
+        cls.resident = cls._create_user("tenant@example.com", RoleChoices.TENANT)
+        cls.altre_resident = cls._create_user("tenant2@example.com", RoleChoices.TENANT)
 
-		cls.grup = GrupComparable.objects.create(
-			idGrup=1,
-			zonaClimatica="C2",
-			tipologia="Residencial",
-			rangSuperficie="100-200",
-		)
+        cls.grup = GrupComparable.objects.create(
+            idGrup=1,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="100-200",
+        )
 
-		cls.edifici_1 = cls._create_edifici("EDI-1", administrador=cls.admin_finca, grup=cls.grup)
-		cls.edifici_2 = cls._create_edifici("EDI-2", administrador=cls.altre_admin_finca, grup=cls.grup)
+        cls.edifici_1 = cls._create_edifici("EDI-1", administrador=cls.admin_finca, grup=cls.grup)
+        cls.edifici_2 = cls._create_edifici("EDI-2", administrador=cls.altre_admin_finca, grup=cls.grup)
 
-		cls.habitatge_1 = Habitatge.objects.create(
-			referenciaCadastral="HAB-1",
-			planta="1",
-			porta="A",
-			superficie=80,
-			edifici=cls.edifici_1,
-			usuari=cls.resident,
-		)
-		cls.habitatge_2 = Habitatge.objects.create(
-			referenciaCadastral="HAB-2",
-			planta="2",
-			porta="B",
-			superficie=95,
-			edifici=cls.edifici_2,
-			usuari=cls.altre_resident,
-		)
+        cls.habitatge_1 = Habitatge.objects.create(
+            referenciaCadastral="HAB-1",
+            planta="1",
+            porta="A",
+            superficie=80,
+            edifici=cls.edifici_1,
+            usuari=cls.resident,
+        )
+        cls.habitatge_2 = Habitatge.objects.create(
+            referenciaCadastral="HAB-2",
+            planta="2",
+            porta="B",
+            superficie=95,
+            edifici=cls.edifici_2,
+            usuari=cls.altre_resident,
+        )
 
-	def test_resident_me_edificis_returns_only_linked_buildings(self):
-		"""Resident can see only buildings where they have an apartment."""
-		self.client.force_authenticate(user=self.resident)
+    def test_resident_me_edificis_returns_only_linked_buildings(self):
+        """Resident can see only buildings where they have an apartment."""
+        self.client.force_authenticate(user=self.resident)
 
-		response = self.client.get(reverse("me-edificis"))
+        response = self.client.get(reverse("me-edificis"))
 
-		self.assertEqual(response.status_code, status.HTTP_200_OK)
-		self.assertEqual(len(response.data), 1)
-		self.assertEqual(response.data[0]["idEdifici"], self.edifici_1.idEdifici)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["idEdifici"], self.edifici_1.idEdifici)
 
-	def test_admin_finca_me_edificis_returns_only_managed_buildings(self):
-		"""AdminFinca can see only buildings they manage."""
-		self.client.force_authenticate(user=self.admin_finca)
+    def test_admin_finca_me_edificis_returns_only_managed_buildings(self):
+        """AdminFinca can see only buildings they manage."""
+        self.client.force_authenticate(user=self.admin_finca)
 
-		response = self.client.get(reverse("me-edificis"))
+        response = self.client.get(reverse("me-edificis"))
 
-		self.assertEqual(response.status_code, status.HTTP_200_OK)
-		self.assertEqual(len(response.data), 1)
-		self.assertEqual(response.data[0]["idEdifici"], self.edifici_1.idEdifici)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["idEdifici"], self.edifici_1.idEdifici)
 
-	def test_admin_sistema_me_edificis_returns_all_buildings(self):
-		"""AdminSistema can see all buildings in the system."""
-		self.client.force_authenticate(user=self.admin)
+    def test_admin_sistema_me_edificis_returns_all_buildings(self):
+        """AdminSistema can see all buildings in the system."""
+        self.client.force_authenticate(user=self.admin)
 
-		response = self.client.get(reverse("me-edificis"))
+        response = self.client.get(reverse("me-edificis"))
 
-		self.assertEqual(response.status_code, status.HTTP_200_OK)
-		returned_ids = {item["idEdifici"] for item in response.data}
-		self.assertEqual(returned_ids, {self.edifici_1.idEdifici, self.edifici_2.idEdifici})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {item["idEdifici"] for item in response.data}
+        self.assertEqual(returned_ids, {self.edifici_1.idEdifici, self.edifici_2.idEdifici})
 
 
 class SecurityTests(BaseTestData):
-	"""Tests for security vulnerabilities (overposting, privilege escalation, etc)."""
+    """Tests for security vulnerabilities (overposting, privilege escalation, etc)."""
 
-	@classmethod
-	def setUpTestData(cls):
-		"""Set up users for security testing."""
-		cls.admin = cls._create_user("admin@example.com", RoleChoices.ADMIN)
-		cls.admin_finca = cls._create_user("owner@example.com", RoleChoices.OWNER)
-		cls.altre_resident = cls._create_user("tenant2@example.com", RoleChoices.TENANT)
+    @classmethod
+    def setUpTestData(cls):
+        """Set up users for security testing."""
+        cls.admin = cls._create_user("admin@example.com", RoleChoices.ADMIN)
+        cls.admin_finca = cls._create_user("owner@example.com", RoleChoices.OWNER)
+        cls.altre_resident = cls._create_user("tenant2@example.com", RoleChoices.TENANT)
 
-		cls.grup = GrupComparable.objects.create(
-			idGrup=1,
-			zonaClimatica="C2",
-			tipologia="Residencial",
-			rangSuperficie="100-200",
-		)
+        cls.grup = GrupComparable.objects.create(
+            idGrup=1,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="100-200",
+        )
 
-		cls.edifici_1 = cls._create_edifici("EDI-1", administrador=cls.admin_finca, grup=cls.grup)
+        cls.edifici_1 = cls._create_edifici("EDI-1", administrador=cls.admin_finca, grup=cls.grup)
 
-		cls.habitatge_1 = Habitatge.objects.create(
-			referenciaCadastral="HAB-1",
-			planta="1",
-			porta="A",
-			superficie=80,
-			edifici=cls.edifici_1,
-			usuari=cls._create_user("tenant@example.com", RoleChoices.TENANT),
-		)
+        cls.habitatge_1 = Habitatge.objects.create(
+            referenciaCadastral="HAB-1",
+            planta="1",
+            porta="A",
+            superficie=80,
+            edifici=cls.edifici_1,
+            usuari=cls._create_user("tenant@example.com", RoleChoices.TENANT),
+        )
 
-	def test_assign_resident_rejects_overposting_sensitive_fields(self):
-		"""Overposting attack: serializer prevents setting unintended fields."""
-		self.client.force_authenticate(user=self.admin_finca)
+    def test_assign_resident_rejects_overposting_sensitive_fields(self):
+        """Overposting attack: serializer prevents setting unintended fields."""
+        self.client.force_authenticate(user=self.admin_finca)
 
-		response = self.client.patch(
-			reverse("assignar-resident", args=[self.habitatge_1.referenciaCadastral]),
-			{
-				"user_id": self.altre_resident.id,
-				"administradorFinca": self.admin.id,
-			},
-			format="json",
-		)
+        response = self.client.patch(
+            reverse("assignar-resident", args=[self.habitatge_1.referenciaCadastral]),
+            {
+                "user_id": self.altre_resident.id,
+                "administradorFinca": self.admin.id,
+            },
+            format="json",
+        )
 
-		self.assertIn(response.status_code, [status.HTTP_200_OK, status.HTTP_400_BAD_REQUEST])
-		self.habitatge_1.refresh_from_db()
-		self.assertEqual(self.habitatge_1.usuari_id, self.altre_resident.id)
-		self.habitatge_1.edifici.refresh_from_db()
-		self.assertEqual(self.habitatge_1.edifici.administradorFinca_id, self.admin_finca.id)
+        self.assertIn(response.status_code, [status.HTTP_200_OK, status.HTTP_400_BAD_REQUEST])
+        self.habitatge_1.refresh_from_db()
+        self.assertEqual(self.habitatge_1.usuari_id, self.altre_resident.id)
+        self.habitatge_1.edifici.refresh_from_db()
+        self.assertEqual(self.habitatge_1.edifici.administradorFinca_id, self.admin_finca.id)
 
-	def test_register_cannot_escalate_to_admin_role(self):
-		"""Privilege escalation: register endpoint rejects role=admin requests."""
-		response = self.client.post(
-			reverse("register"),
-			{
-				"email": "evil-admin@example.com",
-				"first_name": "Evil",
-				"last_name": "User",
-				"password": "Password123",
-				"password_confirm": "Password123",
-				"role": RoleChoices.ADMIN,
-			},
-			format="json",
-		)
+    def test_register_cannot_escalate_to_admin_role(self):
+        """Privilege escalation: register endpoint rejects role=admin requests."""
+        response = self.client.post(
+            reverse("register"),
+            {
+                "email": "evil-admin@example.com",
+                "first_name": "Evil",
+                "last_name": "User",
+                "password": "Password123",
+                "password_confirm": "Password123",
+                "role": RoleChoices.ADMIN,
+            },
+            format="json",
+        )
 
-		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-		self.assertFalse(User.objects.filter(email="evil-admin@example.com").exists())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(User.objects.filter(email="evil-admin@example.com").exists())


### PR DESCRIPTION
# Què s'ha fet
- S'ha afegit auto-creació de `Profile` mitjançant signals en crear un `User`
- S'ha adaptat el registre per reutilitzar/actualitzar el perfil existent
- S'ha alineat la validació de contrasenya amb els validators de Django
- S'han actualitzat els tests d'accounts perquè siguin compatibles amb el nou flux

# Motivació
Això evita usuaris sense `Profile`, elimina errors per duplicació de perfil i reforça la consistència del flux d'autenticació de l'EPIC 1.

# Validació
- `python manage.py test apps.accounts` 