### PR TITLE
Implementació de la gestió de perfil d’usuari (US5, US6, US7).

### DIFF
--- a/backend/apps/accounts/serializers.py
+++ b/backend/apps/accounts/serializers.py
@@ -225,3 +225,14 @@ class AccountUpdateSerializer(serializers.ModelSerializer):
         instance.last_name = validated_data.get("last_name", instance.last_name)
         instance.save(update_fields=["first_name", "last_name"])
         return instance
+
+class RoleUpdateSerializer(serializers.Serializer):
+    role = serializers.ChoiceField(choices=RoleChoices.choices)
+
+    def validate_role(self, value):
+        allowed_roles = {RoleChoices.OWNER, RoleChoices.TENANT}
+        if value not in allowed_roles:
+            raise serializers.ValidationError(
+                "Només es permet canviar entre els rols owner i tenant."
+            )
+        return value

--- a/backend/apps/accounts/tests.py
+++ b/backend/apps/accounts/tests.py
@@ -315,6 +315,56 @@ class MeRoleViewTests(BaseTestData):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+class MeViewTests(BaseTestData):
+    """Tests for authenticated user's profile retrieval and update endpoint."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = cls._create_user("meview@example.com", RoleChoices.OWNER)
+
+    def test_authenticated_user_can_get_own_profile(self):
+        """Authenticated user can retrieve own profile data."""
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(reverse("me"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], self.user.id)
+        self.assertEqual(response.data["email"], self.user.email)
+        self.assertEqual(response.data["first_name"], self.user.first_name)
+        self.assertEqual(response.data["role"], RoleChoices.OWNER)
+
+    def test_authenticated_user_can_patch_own_profile(self):
+        """Authenticated user can update own basic profile fields."""
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.patch(
+            reverse("me"),
+            {"first_name": "Marti", "last_name": "Borras"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.first_name, "Marti")
+        self.assertEqual(self.user.last_name, "Borras")
+        self.assertEqual(response.data["first_name"], "Marti")
+        self.assertEqual(response.data["last_name"], "Borras")
+
+    def test_unauthenticated_user_cannot_get_profile(self):
+        """Unauthenticated requests to profile detail must return 401."""
+        response = self.client.get(reverse("me"))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_unauthenticated_user_cannot_patch_profile(self):
+        """Unauthenticated requests to profile update must return 401."""
+        response = self.client.patch(
+            reverse("me"),
+            {"first_name": "NoAuth"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
 class QuerySetFilteringTests(BaseTestData):
     """Tests for queryset filtering to prevent ABAC/RBAC bypasses and data leaks."""
 

--- a/backend/apps/accounts/tests.py
+++ b/backend/apps/accounts/tests.py
@@ -250,6 +250,70 @@ class AssignmentTests(BaseTestData):
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+class MeRoleViewTests(BaseTestData):
+    """Tests for authenticated user's role change endpoint."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = cls._create_user("perfil@example.com", RoleChoices.OWNER)
+
+    def test_authenticated_user_can_change_role_to_tenant(self):
+        """Authenticated user can change own role from owner to tenant."""
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.patch(
+            reverse("me-role"),
+            {"role": RoleChoices.TENANT},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.role, RoleChoices.TENANT)
+        self.assertEqual(response.data["role"], RoleChoices.TENANT)
+
+    def test_authenticated_user_can_change_role_to_owner(self):
+        """Authenticated user can change own role from tenant to owner."""
+        self.user.profile.role = RoleChoices.TENANT
+        self.user.profile.save(update_fields=["role"])
+
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.patch(
+            reverse("me-role"),
+            {"role": RoleChoices.OWNER},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.role, RoleChoices.OWNER)
+        self.assertEqual(response.data["role"], RoleChoices.OWNER)
+
+    def test_authenticated_user_cannot_change_role_to_admin(self):
+        """Authenticated user cannot escalate own role to admin."""
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.patch(
+            reverse("me-role"),
+            {"role": RoleChoices.ADMIN},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.user.profile.refresh_from_db()
+        self.assertEqual(self.user.profile.role, RoleChoices.OWNER)
+        self.assertIn("role", response.data)
+
+    def test_unauthenticated_user_cannot_change_role(self):
+        """Unauthenticated requests must return 401."""
+        response = self.client.patch(
+            reverse("me-role"),
+            {"role": RoleChoices.TENANT},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 class QuerySetFilteringTests(BaseTestData):
     """Tests for queryset filtering to prevent ABAC/RBAC bypasses and data leaks."""

--- a/backend/apps/accounts/urls.py
+++ b/backend/apps/accounts/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from apps.accounts.views import (
-    RegisterView, LoginView, TokenRefreshView, LogoutView, MeView,
+    RegisterView, LoginView, TokenRefreshView, LogoutView, MeView, MeRoleView,
     MeEdificisView, AssignarResidentView, AssignarAdminEdificiView,
 )
 
@@ -12,13 +12,22 @@ urlpatterns = [
     path("refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("logout/", LogoutView.as_view(), name="logout"),
     path("me/", MeView.as_view(), name="me"),
+    path("me/role/", MeRoleView.as_view(), name="me-role"),
 
     # Consulta: edificis accessibles per l'usuari autenticat
     path("me/edificis/", MeEdificisView.as_view(), name="me-edificis"),
 
     # Assignació: resident → habitatge (AdminFinca, ABAC-B)
-    path("habitatges/<str:ref_cadastral>/assignar-resident/", AssignarResidentView.as_view(), name="assignar-resident"),
+    path(
+        "habitatges/<str:ref_cadastral>/assignar-resident/",
+        AssignarResidentView.as_view(),
+        name="assignar-resident",
+    ),
 
     # Assignació: admin → edifici (AdminSistema only)
-    path("edificis/<int:id_edifici>/assignar-admin/", AssignarAdminEdificiView.as_view(), name="assignar-admin-edifici"),
+    path(
+        "edificis/<int:id_edifici>/assignar-admin/",
+        AssignarAdminEdificiView.as_view(),
+        name="assignar-admin-edifici",
+    ),
 ]

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -10,11 +10,10 @@ from apps.accounts.permissions import IsAdminSistema, IsAdminFinca, ABACMixin
 from apps.accounts.throttles import LoginThrottle, RegisterThrottle, RefreshThrottle
 from apps.accounts.serializers import (
     RegisterSerializer, LoginSerializer, LogoutSerializer, MeSerializer,
-    AccountUpdateSerializer,
+    AccountUpdateSerializer, RoleUpdateSerializer,
     EdificiResumSerializer, HabitatgeResumSerializer,
     AssignarResidentSerializer, AssignarAdminSerializer,
 )
-
 
 class RegisterView(generics.CreateAPIView):
     serializer_class = RegisterSerializer
@@ -176,3 +175,25 @@ class AssignarAdminEdificiView(APIView):
         edifici.save(update_fields=['administradorFinca_id'])
 
         return Response(EdificiResumSerializer(edifici).data)
+
+# ---------------------------------------------------------------------------
+# Canvi de rol (US5)
+# ---------------------------------------------------------------------------
+
+class MeRoleView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def patch(self, request):
+        serializer = RoleUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        profile = request.user.profile
+        new_role = serializer.validated_data["role"]
+
+        profile.role = new_role
+        profile.save(update_fields=["role", "updated_at"])
+
+        return Response(
+            MeSerializer(request.user).data,
+            status=status.HTTP_200_OK
+        )


### PR DESCRIPTION
Funcionalitat:
- Endpoint GET /accounts/me/ per visualitzar el perfil d’usuari
- Endpoint PATCH /accounts/me/ per actualitzar dades bàsiques (nom i cognoms)
- Nou endpoint PATCH /accounts/me/role/ per permetre el canvi de rol

Seguretat:
- S’evita l’escalada de privilegis impedint assignar el rol admin des de l’endpoint

Testing:
- S’han afegit tests per:
  - visualització del perfil
  - edició del perfil
  - canvi de rol
  - control d’accés per usuaris no autenticats

Validació:
- S’ha executat tota la suite de tests del mòdul accounts sense errors