### PR TITLE
Configura CORS CSRF i valors per entorns

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -61,7 +61,13 @@ jobs:
       DJANGO_SETTINGS_MODULE: config.settings
       PYTHONUNBUFFERED: 1
       DEBUG: "False"
+      ENVIRONMENT: test
       ENABLE_DEBUG_TOOLBAR: "False"
+      ALLOWED_HOSTS: "localhost,127.0.0.1,0.0.0.0"
+      CORS_ALLOWED_ORIGINS: "http://localhost,http://127.0.0.1"
+      CSRF_TRUSTED_ORIGINS: "http://localhost,http://127.0.0.1"
+      CORS_ALLOW_ALL_ORIGINS: "False"
+      CORS_ALLOW_CREDENTIALS: "True"
 
     steps:
       - name: Checkout repository

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -15,6 +15,25 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
+
+def env_bool(name: str, default: bool = False) -> bool:
+    value = os.environ.get(name)
+
+    if value is None:
+        return default
+
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def env_list(name: str, default: str = "") -> list[str]:
+    value = os.environ.get(name, default)
+
+    return [
+        item.strip()
+        for item in value.split(",")
+        if item.strip()
+    ]
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -28,10 +47,15 @@ load_dotenv(BASE_DIR / ".env")
 SECRET_KEY = 'django-insecure-fvw+7u7o-m!1$r0hy6=7q#xb*l-#f9#ink&hk4153utnf^$3w)'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv("DEBUG", "True").lower() == "true"
+ENVIRONMENT = os.environ.get("ENVIRONMENT", "development")
+
+DEBUG = env_bool("DEBUG", default=ENVIRONMENT != "production")
 ENABLE_DEBUG_TOOLBAR = os.getenv("ENABLE_DEBUG_TOOLBAR", "False").lower() == "true"
 
-ALLOWED_HOSTS = ["*"]
+ALLOWED_HOSTS = env_list(
+    "ALLOWED_HOSTS",
+    default="localhost,127.0.0.1,0.0.0.0",
+)
 
 
 # Application definition
@@ -145,8 +169,6 @@ STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-CORS_ALLOW_ALL_ORIGINS = True
-
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_simplejwt.authentication.JWTAuthentication',
@@ -197,3 +219,42 @@ if DEBUG:
 
 # Third-party API key 
 THIRD_PARTY_API_KEY = os.getenv("THIRD_PARTY_API_KEY")
+
+# -----------------------------------------------------------------------------
+# Entorns / CORS / CSRF
+# -----------------------------------------------------------------------------
+# Les variables següents permeten separar comportament de desenvolupament,
+# test i producció sense modificar el codi. En producció NO s'hauria d'usar
+# CORS_ALLOW_ALL_ORIGINS=True.
+
+CORS_ALLOW_ALL_ORIGINS = env_bool("CORS_ALLOW_ALL_ORIGINS", default=False)
+
+CORS_ALLOWED_ORIGINS = env_list(
+    "CORS_ALLOWED_ORIGINS",
+    default=(
+        "http://localhost,"
+        "http://127.0.0.1,"
+        "http://localhost:3000,"
+        "http://127.0.0.1:3000,"
+        "http://localhost:5173,"
+        "http://127.0.0.1:5173,"
+        "http://localhost:8080,"
+        "http://127.0.0.1:8080"
+    ),
+)
+
+CSRF_TRUSTED_ORIGINS = env_list(
+    "CSRF_TRUSTED_ORIGINS",
+    default=(
+        "http://localhost,"
+        "http://127.0.0.1,"
+        "http://localhost:3000,"
+        "http://127.0.0.1:3000,"
+        "http://localhost:5173,"
+        "http://127.0.0.1:5173,"
+        "http://localhost:8080,"
+        "http://127.0.0.1:8080"
+    ),
+)
+
+CORS_ALLOW_CREDENTIALS = env_bool("CORS_ALLOW_CREDENTIALS", default=True)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,12 @@ services:
     command: sh -c "python manage.py collectstatic --noinput && gunicorn --config gunicorn.conf.py config.wsgi:application"
     environment:
       DEBUG:       "True"
+      ENVIRONMENT: "development"
+      ALLOWED_HOSTS: "localhost,127.0.0.1,0.0.0.0"
+      CORS_ALLOWED_ORIGINS: "http://localhost,http://127.0.0.1,http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173,http://localhost:8080,http://127.0.0.1:8080"
+      CSRF_TRUSTED_ORIGINS: "http://localhost,http://127.0.0.1,http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173,http://localhost:8080,http://127.0.0.1:8080"
+      CORS_ALLOW_ALL_ORIGINS: "False"
+      CORS_ALLOW_CREDENTIALS: "True"
       DB_HOST:     db
       DB_PORT:     "5432"
       DB_NAME:     buildrank


### PR DESCRIPTION
## Resum

Aquest PR afegeix la configuració bàsica de seguretat web i separació d’entorns al backend de BuildRank.

### Canvis principals

- S’ha afegit `django-cors-headers` com a dependència del backend.
- S’ha configurat CORS mitjançant `CORS_ALLOWED_ORIGINS`.
- S’ha evitat obrir CORS globalment amb `CORS_ALLOW_ALL_ORIGINS=True`.
- S’han configurat `CSRF_TRUSTED_ORIGINS`.
- S’ha configurat `ALLOWED_HOSTS` mitjançant variables d’entorn.
- S’ha afegit la variable `ENVIRONMENT` per diferenciar development, test i production.
- S’ha actualitzat `docker-compose.yml` amb valors explícits per entorn local.
- S’ha actualitzat el backend CI amb variables d’entorn explícites.

### Motivació

Aquesta configuració evita bloquejos del frontend quan consumeix l’API des d’orígens locals o de staging, i millora la seguretat perquè els orígens permesos queden controlats per entorn.

### Validació local

S’han executat:

```bash
docker compose exec web python manage.py check
docker compose exec web python manage.py makemigrations --check --dry-run
docker compose exec web python manage.py test apps.accounts apps.buildings