### PR TITLE
docs: testing i validació US1–US7 (accounts)

### DIFF
--- a/docs/testing/test-cases.md
+++ b/docs/testing/test-cases.md
@@ -1,0 +1,33 @@
+# Test Cases – Accounts Backend (US1–US7)
+
+| ID | US | Tipus | Endpoint | Test automatitzat | Resultat esperat | Estat |
+|---|---|---|---|---|---|---|
+| TC-ACC-001 | US1 | API | POST /register/ | test_register_success_creates_user_profile_and_default_role | 201 + usuari i perfil creats amb rol per defecte | Pass |
+| TC-ACC-002 | US1 | API | POST /register/ | test_register_success_with_explicit_owner_role | 201 + usuari creat amb rol owner | Pass |
+| TC-ACC-003 | US1 | API | POST /register/ | test_register_rejects_duplicate_email | 400 + email duplicat rebutjat | Pass |
+| TC-ACC-004 | US1 | API | POST /register/ | test_register_rejects_password_mismatch | 400 + passwords no coincidents | Pass |
+| TC-ACC-005 | US1 | API | POST /register/ | test_register_rejects_password_without_letters | 400 + password invàlida | Pass |
+| TC-ACC-006 | US1 | API | POST /register/ | test_register_rejects_password_without_digits | 400 + password invàlida | Pass |
+| TC-ACC-007 | US1 | Seguretat | POST /register/ | test_register_throttle_5_per_hour | 429 + límit de peticions aplicat | Pass |
+| TC-ACC-008 | US2 | API | POST /login/ | test_login_success_returns_tokens_user_and_creates_audit_log | 200 + tokens + log creat | Pass |
+| TC-ACC-009 | US2 | API | POST /login/ | test_login_rejects_invalid_credentials | 401 + credencials incorrectes | Pass |
+| TC-ACC-010 | US2 | Seguretat | POST /login/ | test_login_session_limit_blacklists_oldest_refresh_token | Token antic invalidat | Pass |
+| TC-ACC-011 | US2 | Seguretat | POST /login/ | test_login_throttle_3_per_minute | 429 + límit de peticions | Pass |
+| TC-ACC-012 | US3 | API | POST /logout/ | test_logout_success_revokes_refresh_and_updates_audit_log | 200 + refresh revocat | Pass |
+| TC-ACC-013 | US3 | API | POST /logout/ | test_logout_rejects_invalid_refresh_token | 400 + refresh invàlid | Pass |
+| TC-ACC-014 | US3 | Seguretat | POST /logout/ | test_logout_then_refresh_reuse_fails | 401 + token no reutilitzable | Pass |
+| TC-ACC-015 | US4 | API | POST /register/ | test_register_success_creates_user_profile_and_default_role | Rol inicial assignat | Pass |
+| TC-ACC-016 | US5 | API | PATCH /me/role/ | test_authenticated_user_can_change_role_to_tenant | 200 + rol canviat | Pass |
+| TC-ACC-017 | US5 | API | PATCH /me/role/ | test_authenticated_user_can_change_role_to_owner | 200 + rol canviat | Pass |
+| TC-ACC-018 | US5 | Permisos | PATCH /me/role/ | test_authenticated_user_cannot_change_role_to_admin | 403 + accés denegat | Pass |
+| TC-ACC-019 | US5 | Permisos | PATCH /me/role/ | test_unauthenticated_user_cannot_change_role | 401 + no autenticat | Pass |
+| TC-ACC-020 | US6 | API | PATCH /me/ | test_authenticated_user_can_patch_own_profile | 200 + perfil actualitzat | Pass |
+| TC-ACC-021 | US6 | API | PATCH /me/ | test_authenticated_user_can_patch_own_account | 200 + compte actualitzat | Pass |
+| TC-ACC-022 | US6 | API | PUT /me/ | test_authenticated_user_can_put_own_account | 200 + compte reemplaçat | Pass |
+| TC-ACC-023 | US6 | API | PATCH /me/ | test_update_account_rejects_duplicate_email | 400 + email duplicat | Pass |
+| TC-ACC-024 | US6 | Seguretat | PATCH /me/ | test_update_account_ignores_role_field | Rol no modificable | Pass |
+| TC-ACC-025 | US7 | API | GET /me/ | test_authenticated_user_can_get_own_profile | 200 + perfil retornat | Pass |
+| TC-ACC-026 | US7 | API | GET /me/ | test_me_returns_current_user_profile_data | Dades coherents | Pass |
+| TC-ACC-027 | US7 | Permisos | GET /me/ | test_me_requires_authentication | 401 + no autenticat | Pass |
+| TC-ACC-028 | US7 | Seguretat | GET /me/ | test_me_with_tampered_access_token_fails | 401 + token invàlid | Pass |
+| TC-ACC-029 | US7 | Seguretat | GET /me/ | test_me_with_expired_access_token_fails | 401 + token expirat | Pass |

--- a/docs/testing/test-execution-report.md
+++ b/docs/testing/test-execution-report.md
@@ -1,0 +1,81 @@
+# Test Execution Report – Accounts Backend
+
+## Executor
+Martí Borràs
+
+## Branca
+testing-us1-us7
+
+## Àmbit
+US1, US2, US3, US4, US5, US6 i US7.
+
+## Comandes executades
+
+```bash
+docker compose exec web python manage.py check
+docker compose exec web python manage.py makemigrations --check --dry-run
+docker compose exec web python manage.py test apps.accounts
+docker compose exec web coverage run manage.py test apps.accounts
+docker compose exec web coverage report --include="apps/accounts/*"
+```
+
+## Resultats
+
+- **manage.py check:** OK  
+- **makemigrations --check --dry-run:** No changes detected  
+- **Tests executats (apps.accounts):** 52  
+- **Tests correctes:** 52  
+- **Tests skipped:** 2  
+- **Coverage (apps.accounts):** 88%
+
+## Validacions realitzades
+
+### Django
+- Validació de configuració correcta del projecte  
+- No s’han detectat errors de sistema  
+
+### Docker
+- Entorn aixecat correctament amb docker compose  
+- Execució de comandes dins del contenidor sense errors  
+
+### Postman
+S’han validat manualment els endpoints:
+
+- `POST /register/`
+- `POST /login/`
+- `POST /logout/`
+- `GET /me/`
+- `PATCH /me/`
+- `PATCH /me/role/`
+
+Verificant:
+- Codis HTTP correctes  
+- Format de resposta JSON  
+- Gestió d’errors  
+
+### DBeaver
+S’ha verificat la persistència de:
+
+- Usuaris  
+- Perfils  
+- Rols  
+- Logs d’autenticació  
+
+Confirmant coherència entre API i base de dades PostgreSQL.
+
+## Incidències
+
+No s’han detectat incidències crítiques durant l’execució de les proves.
+
+## Conclusions
+
+La funcionalitat corresponent a les US1–US7 (registre, autenticació, gestió de rols i perfil) es considera estable.
+
+El sistema:
+- Passa tots els tests automatitzats  
+- No presenta errors de configuració  
+- No té migracions pendents  
+- Manté una cobertura del 88% en l’app accounts  
+- Valida correctament els fluxos d’autenticació i permisos  
+
+Per tant, es considera que aquestes funcionalitats compleixen els criteris de qualitat definits i poden integrar-se al sistema sense risc de regressió.

--- a/docs/testing/test-plan.md
+++ b/docs/testing/test-plan.md
@@ -1,0 +1,46 @@
+# Test Plan – Backend (US1–US7)
+
+## Objectiu
+Validar el correcte funcionament del sistema d’autenticació i gestió d’usuaris:
+registre, login, logout, perfil i gestió de rols.
+
+## Abast
+Aquest pla cobreix:
+- US1 – Registre
+- US2 – Login
+- US3 – Logout
+- US4 – Rol inicial
+- US5 – Canvi de rol
+- US6 – Edició de perfil
+- US7 – Visualització de perfil
+
+## Tipus de proves
+- Tests automatitzats (Django TestCase / API tests)
+- Proves manuals d’API (Postman)
+- Verificació de persistència (DBeaver)
+- Validació d’entorn (Docker)
+- Validació automàtica en CI
+
+## Eines
+- Django TestCase / APITestCase
+- Docker Compose
+- Postman
+- DBeaver
+- coverage.py
+- GitHub Actions (CI)
+
+## Estratègia
+El testing es basa en una estratègia incremental i basada en risc, prioritzant:
+- autenticació
+- permisos
+- gestió de sessions
+
+## Criteris d’acceptació
+Una funcionalitat es considera correcta si:
+- retorna codis HTTP adequats
+- valida correctament errors
+- persisteix dades a PostgreSQL
+- passa els tests automatitzats
+- no té migracions pendents (`makemigrations --check --dry-run`)
+- passa els checks de CI
+- té evidència documentada de la seva validació


### PR DESCRIPTION
En aquest PR s’ha completat la part de testing i documentació corresponent a les US1–US7 (gestió d’usuaris i autenticació).

S’ha treballat sobre:
- registre (US1)
- login (US2)
- logout (US3)
- rol inicial (US4)
- canvi de rol (US5)
- edició de perfil (US6)
- visualització de perfil (US7)

Testing realitzat:
- Tests automatitzats amb Django REST (apps.accounts)
- Execució dins de Docker
- Coverage específic de la app accounts: 88%
- Validació manual d’endpoints amb Postman
- Verificació de persistència amb DBeaver

Documentació afegida:
- docs/testing/test-plan.md
- docs/testing/test-cases.md
- docs/testing/test-execution-report.md

Resultat:
- 52 tests executats correctament
- 2 tests skipped
- sense migracions pendents
- sistema estable i validat

Aquest PR completa la tasca de testing i qualitat per la part de backend associada a les US1–US7.