### PR TITLE
Fix - Permetre accés local des de dispositius mòbils

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,11 +27,11 @@ services:
     environment:
       DEBUG:       "True"
       ENVIRONMENT: "development"
-      ALLOWED_HOSTS: "localhost,127.0.0.1,0.0.0.0"
-      CORS_ALLOWED_ORIGINS: "http://localhost,http://127.0.0.1,http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173,http://localhost:8080,http://127.0.0.1:8080"
-      CSRF_TRUSTED_ORIGINS: "http://localhost,http://127.0.0.1,http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173,http://localhost:8080,http://127.0.0.1:8080"
-      CORS_ALLOW_ALL_ORIGINS: "False"
-      CORS_ALLOW_CREDENTIALS: "True"
+      ALLOWED_HOSTS: "${ALLOWED_HOSTS:-*}"
+      CORS_ALLOWED_ORIGINS: "${CORS_ALLOWED_ORIGINS:-http://localhost,http://127.0.0.1,http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173,http://localhost:8080,http://127.0.0.1:8080}"
+      CSRF_TRUSTED_ORIGINS: "${CSRF_TRUSTED_ORIGINS:-http://localhost,http://127.0.0.1,http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173,http://localhost:8080,http://127.0.0.1:8080}"
+      CORS_ALLOW_ALL_ORIGINS: "${CORS_ALLOW_ALL_ORIGINS:-True}"
+      CORS_ALLOW_CREDENTIALS: "${CORS_ALLOW_CREDENTIALS:-True}"
       DB_HOST:     db
       DB_PORT:     "5432"
       DB_NAME:     buildrank


### PR DESCRIPTION
## Resum

Aquest PR ajusta la configuració local de `docker-compose.yml` perquè el backend de BuildRank pugui rebre peticions des de dispositius mòbils físics connectats a la mateixa xarxa local que l’ordinador de desenvolupament.

Això facilita que qualsevol membre de l’equip pugui provar l’app Flutter des del seu propi mòbil sense haver d’editar manualment `ALLOWED_HOSTS` amb la seva IP local.

---

## Problema detectat

Quan un mòbil físic intentava fer login contra el backend utilitzant la IP local del PC, Django retornava un error de tipus:

```text
Invalid HTTP_HOST header: '192.168.1.xxx'. You may need to add '192.168.1.xxx' to ALLOWED_HOSTS.
```

## Com provar-ho després de fer pull

Després que aquest PR s’integri a Desenvolupament, cada company que ja tingui els contenidors aixecats haurà d’executar:

```bash
git checkout Desenvolupament
git pull origin Desenvolupament
docker compose up -d --force-recreate web nginx
docker compose exec web python manage.py check
```

És important executar:

```bash
docker compose up -d --force-recreate web nginx
```


perquè ALLOWED_HOSTS i CORS_ALLOW_ALL_ORIGINS són variables d’entorn del contenidor. Si només es fa git pull, el fitxer docker-compose.yml canvia al disc, però els contenidors ja creats continuen funcionant amb les variables antigues.