### PR TITLE
Coords -> Carrer + Num --> DB check

### DIFF
--- a/backend/apps/buildings/services/building_lookup.py
+++ b/backend/apps/buildings/services/building_lookup.py
@@ -1,0 +1,33 @@
+# apps/buildings/services/building_lookup.py
+from apps.buildings.models import Edifici, Localitzacio
+
+
+def buscar_edifici(carrer: str, numero: int | None) -> tuple[Edifici | None, str]:
+    """
+    Cerca l'edifici a la BD seguint dos nivells de precisió:
+      1. Coincidència exacta: carrer + número.
+      2. Coincidència per carrer: qualsevol edifici actiu del mateix carrer.
+
+    Retorna (edifici, nivell_coincidencia).
+    nivell_coincidencia: "exacta" | "carrer" | "cap"
+    """
+    print(f"Buscant edifici per carrer='{carrer}' i numero='{numero}'")
+    qs_carrer = Localitzacio.objects.filter(
+        carrer__iexact=carrer,
+        edifici__actiu=True,
+    ).select_related("edifici")
+
+    print(f"Localitzacions trobades al carrer '{carrer}': {qs_carrer.count()}")
+    if not qs_carrer.exists():
+        return None, "cap"
+
+    if numero is not None:
+        loc_exacta = qs_carrer.filter(numero=numero).first()
+        if loc_exacta and loc_exacta.edifici:
+            return loc_exacta.edifici, "exacta"
+
+    loc_carrer = qs_carrer.first()
+    if loc_carrer and loc_carrer.edifici:
+        return loc_carrer.edifici, "carrer"
+
+    return None, "cap"

--- a/backend/apps/buildings/services/nominatim.py
+++ b/backend/apps/buildings/services/nominatim.py
@@ -1,0 +1,101 @@
+# apps/buildings/services/nominatim.py
+import time
+import logging
+import requests
+
+logger = logging.getLogger(__name__)
+
+NOMINATIM_URL     = "https://nominatim.openstreetmap.org/reverse"
+NOMINATIM_HEADERS = {"User-Agent": "BuildingHealthScoreApp/1.0"}
+
+# Bounding box de Barcelona ciutat (lat_min, lat_max, lng_min, lng_max).
+# Fallback geomètric quan Nominatim no retorna city="Barcelona".
+BARCELONA_BOUNDS = (41.320, 41.470, 2.069, 2.228)
+
+# Política d'ús Nominatim: màxim 1 req/s.
+NOMINATIM_MIN_INTERVAL = 1.1  # segons
+
+
+class NominatimRateLimiter:
+    """
+    Controla que no es facin més d'1 crida/segon a Nominatim.
+    Instancia-la una vegada per bulk i passa-la a reverse_geocode.
+    """
+    def __init__(self):
+        self._last_call = 0.0
+
+    def wait(self):
+        elapsed = time.monotonic() - self._last_call
+        if elapsed < NOMINATIM_MIN_INTERVAL:
+            time.sleep(NOMINATIM_MIN_INTERVAL - elapsed)
+        self._last_call = time.monotonic()
+
+
+def reverse_geocode(lat: float, lng: float, rate_limiter: NominatimRateLimiter) -> dict | None:
+    """
+    Crida Nominatim reverse geocoding respectant el rate limit.
+    Retorna el dict 'address' de la resposta, o None si falla.
+    """
+    rate_limiter.wait()
+
+    try:
+        resp = requests.get(
+            NOMINATIM_URL,
+            params={"lat": lat, "lon": lng, "format": "json", "addressdetails": 1},
+            headers=NOMINATIM_HEADERS,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        return resp.json().get("address", {})
+    except Exception as exc:
+        logger.warning("Nominatim error per (%s, %s): %s", lat, lng, exc)
+        return None
+
+
+def es_barcelona(address: dict, lat: float, lng: float) -> bool:
+    """
+    Comprova si les coordenades pertanyen a Barcelona.
+    Estratègia doble:
+      1. El camp city/town/municipality de Nominatim conté "Barcelona".
+      2. Fallback: les coordenades estan dins el bounding box de la ciutat.
+    """
+    city = (
+        address.get("city")
+        or address.get("town")
+        or address.get("municipality")
+        or ""
+    ).lower()
+
+    if "barcelona" in city:
+        return True
+
+    lat_min, lat_max, lng_min, lng_max = BARCELONA_BOUNDS
+    return lat_min <= lat <= lat_max and lng_min <= lng <= lng_max
+
+
+def parse_carrer_numero(address: dict) -> tuple[str | None, int | None]:
+    """
+    Extreu el nom del carrer i el número de la resposta de Nominatim.
+    Retorna (carrer, numero) o (None, None) si no s'ha pogut parsejar.
+    """
+    carrer = (
+        address.get("road")
+        or address.get("pedestrian")
+        or address.get("footway")
+    )
+
+    if not carrer:
+        return None, None
+
+    carrer = carrer.strip()
+
+    numero_raw = address.get("house_number")
+    numero = None
+    if numero_raw:
+        # Agafem el primer token numèric: "12-14" → 12, "12 bis" → 12.
+        try:
+            numero = int("".join(filter(str.isdigit, numero_raw.split()[0])))
+        except (ValueError, IndexError):
+            numero = None
+
+    return carrer, numero

--- a/backend/apps/buildings/views.py
+++ b/backend/apps/buildings/views.py
@@ -35,6 +35,10 @@ from .permissions import (
     EsAdminMilloraImplementada,
     HasAPIKey,
 )
+
+from .services.nominatim import NominatimRateLimiter, reverse_geocode, es_barcelona, parse_carrer_numero
+from .services.building_lookup import buscar_edifici
+
 from .pagination import RankingPaginacio
 from django.db import transaction
 from .simulation.engine import simular_millores
@@ -769,10 +773,60 @@ class RankingViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class ThirdPartyServiceView(APIView):
+    """
+    POST /api/third-party/score/
+ 
+    Body:
+        { "points": [{"lat": 41.38, "lng": 2.17}, ...] }
+ 
+    Resposta per punt:
+        { "lat": 41.38, "lng": 2.17, "score": 73.4 }
+        { "lat": 41.38, "lng": 2.17, "score": null }   # edifici sense puntuació
+        { "lat": 41.38, "lng": 2.17, "error": "..." }  # fora de BCN, error geocodificació, etc.
+    """
+ 
     permission_classes = [HasAPIKey]
-
-    def get(self, request):
-        lat = request.query_params.get("lat")
-        lng = request.query_params.get("lng")
-
-        return Response(10)
+ 
+    def post(self, request):
+        points = request.data.get("points", [])
+ 
+        if not isinstance(points, list):
+            return Response(
+                {"error": "'points' ha de ser una llista."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+ 
+        rate_limiter = NominatimRateLimiter()
+        results = []
+ 
+        for point in points:
+            lat = point.get("lat")
+            lng = point.get("lng")
+ 
+            if lat is None or lng is None:
+                results.append({"lat": lat, "lng": lng, "error": "Coordenades incompletes."})
+                continue
+ 
+            address = reverse_geocode(lat, lng, rate_limiter)
+            if address is None:
+                results.append({"lat": lat, "lng": lng, "error": "Error de geocodificació."})
+                continue
+ 
+            if not es_barcelona(address, lat, lng):
+                results.append({"lat": lat, "lng": lng, "error": "Coordenades fora de Barcelona."})
+                continue
+ 
+            carrer, numero = parse_carrer_numero(address)
+            if not carrer:
+                results.append({"lat": lat, "lng": lng, "error": "No s'ha pogut determinar el carrer."})
+                continue
+ 
+            edifici, _ = buscar_edifici(carrer, numero)
+ 
+            results.append({
+                "lat": lat,
+                "lng": lng,
+                "score": round(edifici.puntuacioBase, 2) if edifici and edifici.puntuacioBase else None,
+            })
+ 
+        return Response({"results": results})


### PR DESCRIPTION
## Third-party score endpoint

Implementa el servei de puntuació per coordenades externes.

**Flux:**
`(lat, lng)` → Nominatim reverse geocoding → validació Barcelona → cerca BD → `puntuacioBase`

**Fitxers nous:**
- `services/nominatim.py` — geocodificació, rate limiting (1 req/s), validació Barcelona
- `services/building_lookup.py` — cerca edifici per carrer+número o només carrer com a fallback
- `views_third_party.py` — endpoint `POST /api/third-party/score/`

**Cerca en dos nivells:** coincidència exacta (carrer + número) → coincidència per carrer si no n'hi ha (El primer edf del carrer).

> !!! Nominatim públic: ~1 req/s. Per a volums alts considerar servidor propi.