### PR TITLE
fix(auth): improve refresh token session cleanup

### DIFF
--- a/backend/apps/accounts/serializers.py
+++ b/backend/apps/accounts/serializers.py
@@ -12,6 +12,7 @@ from rest_framework_simplejwt.token_blacklist.models import OutstandingToken, Bl
 from django.contrib.auth.password_validation import validate_password
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
+from rest_framework_simplejwt.settings import api_settings
 
 User = get_user_model()
 
@@ -103,11 +104,12 @@ class LoginSerializer(serializers.Serializer):
         # Si hay 5 o más, revoca la más antigua
         self._enforce_session_limit(user)
         
+
         # Registrar login en TokenLoginLog
         TokenLoginLog.objects.create(
             user=user,
             status=TokenLoginLog.LOGIN,
-            expires_at=None,  # Se calcula desde JWT
+            expires_at=timezone.now() + api_settings.REFRESH_TOKEN_LIFETIME,
             jti=jti,
         )
 
@@ -134,7 +136,8 @@ class LoginSerializer(serializers.Serializer):
                 if outstanding:
                     BlacklistedToken.objects.get_or_create(token=outstanding)
                 oldest.status = TokenLoginLog.REVOKED
-                oldest.save(update_fields=['status'])
+                oldest.logout_at = timezone.now()
+                oldest.save(update_fields=['status', 'logout_at'])
 
 
 class LogoutSerializer(serializers.Serializer):


### PR DESCRIPTION
## Resum

Millora la consistència del cicle de vida de les sessions JWT i la neteja de tokens expirats.

### Canvis

* Es persisteix `expires_at` a `TokenLoginLog` utilitzant `REFRESH_TOKEN_LIFETIME`
* Les sessions revocades passen a guardar també `logout_at`
* Es millora la coherència entre sessions actives, revocades i expirades
* Es garanteix que la comanda de neteja pugui detectar correctament sessions expirades

### Motivació

Abans:

* les sessions no es marcaven mai com expirades perquè `expires_at` era `None`
* les sessions revocades podien continuar apareixent com actives perquè `logout_at` seguia sent `null`

### Validació

* Tots els tests de `apps.accounts` passen correctament (`55 passed, 2 skipped`)
* Revisió manual del flux de rotació de refresh tokens i blacklist completada

Closes #26