### PR TITLE
Issue/57 endpoint habitatge

### DIFF
--- a/backend/apps/buildings/serializers.py
+++ b/backend/apps/buildings/serializers.py
@@ -18,6 +18,7 @@ from datetime import date
 
 from apps.accounts.models import RoleChoices
 from .scoring import calcular_classificacio_estimada
+from django.db import transaction
 
 class LocalitzacioSerializer(serializers.ModelSerializer):
     class Meta:
@@ -139,7 +140,78 @@ class HabitatgeDetailSerializer(serializers.ModelSerializer):
         unique_together = ('edifici', 'planta', 'porta')
         fields = '__all__'
 
+class DadesEnergetiquesUpdateSerializer(serializers.ModelSerializer):
+    """Per crear o actualitzar DadesEnergetiques des de l'endpoint de l'habitatge."""
+    class Meta:
+        model = DadesEnergetiques
+        fields = "__all__"
+        # id és read_only per evitar que el frontend intenti forçar un id
+        read_only_fields = ['id']
 
+
+class HabitatgeMeUpdateSerializer(serializers.ModelSerializer):
+    """PATCH /edificis/<id>/me/habitatge/ — camps editables per l'owner/tenant."""
+    dadesEnergetiques = DadesEnergetiquesUpdateSerializer(required=False)
+
+    class Meta:
+        model = Habitatge
+        fields = ['planta', 'porta', 'superficie', 'anyReforma', 'dadesEnergetiques']
+
+    def validate_superficie(self, value):
+        if value <= 0:
+            raise serializers.ValidationError(
+                "La superfície de l'habitatge ha de ser més gran que 0."
+            )
+        return value
+
+    def validate_anyReforma(self, value):
+        if value is not None:
+            any_actual = date.today().year
+            if value > any_actual:
+                raise serializers.ValidationError(
+                    f"L'any de reforma no pot ser del futur (màxim {any_actual})."
+                )
+        return value
+
+    def validate(self, data):
+        any_reforma = data.get('anyReforma')
+        # self.instance és l'habitatge existent (estem sempre en update)
+        if any_reforma is not None and self.instance:
+            any_construccio = self.instance.edifici.anyConstruccio
+            if any_reforma < any_construccio:
+                raise serializers.ValidationError({
+                    "anyReforma": (
+                        f"L'any de reforma ({any_reforma}) no pot ser anterior "
+                        f"a l'any de construcció de l'edifici ({any_construccio})."
+                    )
+                })
+        return data
+
+    def update(self, instance, validated_data):
+        dades_data = validated_data.pop('dadesEnergetiques', None)
+
+        # Actualitzar camps bàsics de l'habitatge
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value)
+        instance.save()
+
+        # Gestionar dadesEnergetiques només si venen al payload
+        if dades_data is not None:
+            with transaction.atomic():
+                if instance.dadesEnergetiques:
+                    # Actualitzar les existents
+                    de = instance.dadesEnergetiques
+                    for attr, value in dades_data.items():
+                        setattr(de, attr, value)
+                    de.save()
+                else:
+                    # Crear i vincular
+                    de = DadesEnergetiques.objects.create(**dades_data)
+                    instance.dadesEnergetiques = de
+                    instance.save(update_fields=["dadesEnergetiques"])
+
+        return instance
+    
 # Edifici 1. Llistat lleuger
 class EdificiListSerializer(serializers.ModelSerializer):
     class Meta:

--- a/backend/apps/buildings/tests.py
+++ b/backend/apps/buildings/tests.py
@@ -2883,3 +2883,273 @@ def test_llistat_pendents_administrador(self):
         self.client.force_authenticate(user=tenant)
         response_denied = self.client.get(url)
         self.assertEqual(response_denied.status_code, status.HTTP_403_FORBIDDEN)
+
+# ============================================================================
+# HABITATGE ME — PATCH /edificis/<id>/me/habitatge/<referenciaCadastral>/
+# ============================================================================
+
+class HabitatgeMeUpdateTests(BaseTestData):
+    """
+    Tests per a l'endpoint PATCH me/habitatge/<ref>/:
+    edició de dades bàsiques i update_or_create de DadesEnergetiques.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.owner = cls._create_user("owner@example.com", RoleChoices.OWNER)
+        cls.other_owner = cls._create_user("other@example.com", RoleChoices.OWNER)
+        cls.tenant = cls._create_user("tenant@example.com", RoleChoices.TENANT)
+
+        cls.grup = GrupComparable.objects.create(
+            idGrup=1, zonaClimatica="C2", tipologia="Residencial", rangSuperficie="0-200"
+        )
+        cls.edifici = cls._create_edifici(cls.owner, cls.grup, numero=10)
+
+        cls.habitatge = Habitatge.objects.create(
+            referenciaCadastral="HAB001",
+            planta="2", porta="1",
+            superficie=80.0,
+            anyReforma=None,
+            edifici=cls.edifici,
+            usuari=cls.owner,
+        )
+        cls.habitatge_tenant = Habitatge.objects.create(
+            referenciaCadastral="HAB002",
+            planta="3", porta="2",
+            superficie=60.0,
+            edifici=cls.edifici,
+            usuari=cls.tenant,
+        )
+
+    def _url(self, edifici_id, ref):
+        return reverse("edifici-me-habitatge", args=[edifici_id, ref])
+
+    def _dades_energetiques_payload(self, **overrides):
+        base = {
+            "qualificacioGlobal": "B",
+            "consumEnergiaPrimaria": 120.5,
+            "consumEnergiaFinal": 95.2,
+            "emissionsCO2": 28.4,
+            "costAnualEnergia": 850,
+            "energiaCalefaccio": 40,
+            "energiaRefrigeracio": 15,
+            "energiaACS": 25,
+            "energiaEnllumenament": 10,
+            "emissionsCalefaccio": 12,
+            "emissionsRefrigeracio": 4,
+            "emissionsACS": 8,
+            "emissionsEnllumenament": 3,
+            "aillamentTermic": 1.2,
+            "valorFinestres": 2.1,
+            "normativa": "CTE 2019",
+            "einaCertificacio": "CE3X",
+            "motiuCertificacio": "Actualització de dades",
+            "rehabilitacioEnergetica": False,
+            "dataEntrada": "2026-04-29",
+        }
+        return {**base, **overrides}
+
+    # ------------------------------------------------------------------
+    # 1. Autenticació i permisos
+    # ------------------------------------------------------------------
+
+    def test_unauthenticated_returns_401(self):
+        """Sense autenticació → 401."""
+        response = self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"), {}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_owner_can_patch_own_habitatge(self):
+        """Owner autenticat pot fer PATCH del seu habitatge → 200."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"superficie": 90.0},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_tenant_can_patch_own_habitatge(self):
+        """Tenant autenticat pot fer PATCH del seu habitatge → 200."""
+        self.client.force_authenticate(user=self.tenant)
+        response = self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB002"),
+            {"superficie": 65.0},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_other_user_cannot_patch_habitatge(self):
+        """Usuari sense relació amb l'habitatge → 404."""
+        self.client.force_authenticate(user=self.other_owner)
+        response = self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"superficie": 90.0},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_wrong_edifici_returns_404(self):
+        """Referència cadastral correcta però edifici incorrecte → 404."""
+        other_edifici = self._create_edifici(self.owner, self.grup, numero=99)
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            self._url(other_edifici.idEdifici, "HAB001"),
+            {"superficie": 90.0},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_nonexistent_habitatge_returns_404(self):
+        """Referència cadastral inexistent → 404."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            self._url(self.edifici.idEdifici, "INEXISTENT"),
+            {"superficie": 90.0},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # ------------------------------------------------------------------
+    # 2. Edició de camps bàsics
+    # ------------------------------------------------------------------
+
+    def test_patch_basic_fields_persisted(self):
+        """Els camps bàsics enviats es guarden correctament a la BD."""
+        self.client.force_authenticate(user=self.owner)
+        self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"planta": "3", "porta": "2", "superficie": 95.5, "anyReforma": 2015},
+            format="json",
+        )
+        self.habitatge.refresh_from_db()
+        self.assertEqual(self.habitatge.planta, "3")
+        self.assertEqual(self.habitatge.porta, "2")
+        self.assertEqual(float(self.habitatge.superficie), 95.5)
+        self.assertEqual(self.habitatge.anyReforma, 2015)
+
+    def test_patch_without_dades_energetiques_does_not_touch_them(self):
+        """Si el payload no inclou dadesEnergetiques, no es crea ni modifica res."""
+        self.client.force_authenticate(user=self.owner)
+        self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"superficie": 85.0},
+            format="json",
+        )
+        self.habitatge.refresh_from_db()
+        self.assertIsNone(self.habitatge.dadesEnergetiques)
+
+    def test_response_contains_full_habitatge(self):
+        """La resposta retorna l'habitatge complet amb dadesEnergetiques nested."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"superficie": 88.0},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("referenciaCadastral", response.data)
+        self.assertIn("dadesEnergetiques", response.data)
+
+    # ------------------------------------------------------------------
+    # 3. Validacions de camps bàsics
+    # ------------------------------------------------------------------
+
+    def test_negative_superficie_rejected(self):
+        """Superfície negativa o zero → 400."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"superficie": -10},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("superficie", response.data)
+
+    def test_future_any_reforma_rejected(self):
+        """Any de reforma en el futur → 400."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"anyReforma": 2099},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("anyReforma", response.data)
+
+    def test_any_reforma_before_construccio_rejected(self):
+        """Any de reforma anterior a la construcció de l'edifici → 400."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"anyReforma": self.edifici.anyConstruccio - 1},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    # ------------------------------------------------------------------
+    # 4. update_or_create de DadesEnergetiques
+    # ------------------------------------------------------------------
+
+    def test_creates_dades_energetiques_when_none_exist(self):
+        """Si l'habitatge no té DadesEnergetiques, es creen i es vinculen."""
+        self.assertIsNone(self.habitatge.dadesEnergetiques)
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"dadesEnergetiques": self._dades_energetiques_payload()},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.habitatge.refresh_from_db()
+        self.assertIsNotNone(self.habitatge.dadesEnergetiques)
+        self.assertEqual(self.habitatge.dadesEnergetiques.qualificacioGlobal, "B")
+
+    def test_updates_existing_dades_energetiques(self):
+        """Si l'habitatge ja té DadesEnergetiques, s'actualitzen sense crear-ne de noves."""
+        dades = DadesEnergetiques.objects.create(**self._dades_energetiques_payload())
+        self.habitatge.dadesEnergetiques = dades
+        self.habitatge.save(update_fields=["dadesEnergetiques"])
+        id_original = dades.id
+
+        self.client.force_authenticate(user=self.owner)
+        self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"dadesEnergetiques": self._dades_energetiques_payload(qualificacioGlobal="A")},
+            format="json",
+        )
+
+        self.habitatge.refresh_from_db()
+        # Mateix objecte (no se n'ha creat un de nou)
+        self.assertEqual(self.habitatge.dadesEnergetiques.id, id_original)
+        self.assertEqual(self.habitatge.dadesEnergetiques.qualificacioGlobal, "A")
+
+    def test_no_orphan_dades_energetiques_on_create(self):
+        """Quan es creen DadesEnergetiques, queden vinculades (no òrfenes)."""
+        self.client.force_authenticate(user=self.owner)
+        self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"dadesEnergetiques": self._dades_energetiques_payload()},
+            format="json",
+        )
+        self.habitatge.refresh_from_db()
+        # La FK inversa ha de trobar exactament aquest habitatge
+        self.assertEqual(
+            self.habitatge.dadesEnergetiques.dades_energetiques.pk,
+            self.habitatge.pk,
+        )
+
+    def test_dades_energetiques_response_nested(self):
+        """La resposta inclou dadesEnergetiques nested amb les dades actualitzades."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            self._url(self.edifici.idEdifici, "HAB001"),
+            {"dadesEnergetiques": self._dades_energetiques_payload(consumEnergiaPrimaria=200.0)},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNotNone(response.data.get("dadesEnergetiques"))
+        self.assertEqual(
+            float(response.data["dadesEnergetiques"]["consumEnergiaPrimaria"]), 200.0
+        )

--- a/backend/apps/buildings/views.py
+++ b/backend/apps/buildings/views.py
@@ -367,29 +367,18 @@ class EdificiViewSet(viewsets.ModelViewSet):
     @action(
         detail=True,
         methods=['patch'],
-        url_path='me/habitatge',
+        url_path='me/habitatge/(?P<referenciaCadastral>[A-Za-z0-9]+)',
         permission_classes=[IsAuthenticated],
     )
-    def me_habitatge(self, request, pk=None):
-        """
-        PATCH /api/buildings/edificis/<id_edifici>/me/habitatge/
-        Permet a owner/tenant editar el seu habitatge vinculat a aquest edifici,
-        incloent la creació o actualització de les seves DadesEnergetiques.
-        """
+    def me_habitatge(self, request, pk=None, referenciaCadastral=None):
         edifici = get_object_or_404(Edifici, pk=pk)
 
-        habitatge = Habitatge.objects.select_related(
-            'dadesEnergetiques', 'edifici'
-        ).filter(
+        habitatge = get_object_or_404(
+            Habitatge.objects.select_related('dadesEnergetiques', 'edifici'),
             edifici=edifici,
             usuari=request.user,
-        ).first()
-
-        if not habitatge:
-            return Response(
-                {"detail": "No tens cap habitatge vinculat a aquest edifici."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+            referenciaCadastral=referenciaCadastral,
+        )
 
         serializer = HabitatgeMeUpdateSerializer(
             habitatge,
@@ -399,7 +388,6 @@ class EdificiViewSet(viewsets.ModelViewSet):
         serializer.is_valid(raise_exception=True)
         serializer.save()
 
-        # Retornem l'habitatge complet (amb dadesEnergetiques nested)
         output = HabitatgeDetailSerializer(habitatge, context={'request': request})
         return Response(output.data, status=status.HTTP_200_OK)
     

--- a/backend/apps/buildings/views.py
+++ b/backend/apps/buildings/views.py
@@ -19,7 +19,7 @@ from .models import (
 )
 from .serializers import (
     EdificiDetailSerializer, EdificiListSerializer,
-    HabitatgeDetailSerializer, HabitatgeResumSerializer,
+    HabitatgeDetailSerializer, HabitatgeMeUpdateSerializer, HabitatgeResumSerializer,
     LocalitzacioSerializer, DadesEnergetiquesSerializer,
     RankingSerializer,
     CatalegMilloraSerializer,
@@ -364,7 +364,45 @@ class EdificiViewSet(viewsets.ModelViewSet):
             return Response({"detail": "No hi ha dades energètiques disponibles."}, status=404)
 
         return Response(dades)
+    @action(
+        detail=True,
+        methods=['patch'],
+        url_path='me/habitatge',
+        permission_classes=[IsAuthenticated],
+    )
+    def me_habitatge(self, request, pk=None):
+        """
+        PATCH /api/buildings/edificis/<id_edifici>/me/habitatge/
+        Permet a owner/tenant editar el seu habitatge vinculat a aquest edifici,
+        incloent la creació o actualització de les seves DadesEnergetiques.
+        """
+        edifici = get_object_or_404(Edifici, pk=pk)
 
+        habitatge = Habitatge.objects.select_related(
+            'dadesEnergetiques', 'edifici'
+        ).filter(
+            edifici=edifici,
+            usuari=request.user,
+        ).first()
+
+        if not habitatge:
+            return Response(
+                {"detail": "No tens cap habitatge vinculat a aquest edifici."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        serializer = HabitatgeMeUpdateSerializer(
+            habitatge,
+            data=request.data,
+            partial=True,
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        # Retornem l'habitatge complet (amb dadesEnergetiques nested)
+        output = HabitatgeDetailSerializer(habitatge, context={'request': request})
+        return Response(output.data, status=status.HTTP_200_OK)
+    
     def _preparar_items_simulacio(self, millores_validated):
         """
         Converteix l'entrada validada del serializer en objectes reals del catàleg.


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>US-H1 · Endpoint per editar l'habitatge i les dades energètiques</h1>
<p>Closes #262 · Closes #263</p>
<h2>Què s'ha implementat</h2>
<p>Nou endpoint autenticat <code>PATCH /api/buildings/edificis/&lt;id_edifici&gt;/me/habitatge/&lt;referenciaCadastral&gt;/</code> que permet a qualsevol usuari autenticat (owner o tenant) editar el seu habitatge vinculat a un edifici, incloent la creació o actualització de les seves <code>DadesEnergetiques</code>.</p>
<h2>Canvis</h2>
<h3><code>serializers.py</code></h3>
<ul>
<li><strong><code>DadesEnergetiquesUpdateSerializer</code></strong> — serialitzador específic per crear o actualitzar <code>DadesEnergetiques</code> des de l'endpoint de l'habitatge.</li>
<li><strong><code>HabitatgeMeUpdateSerializer</code></strong> — serialitzador PATCH per als camps editables de l'habitatge (<code>planta</code>, <code>porta</code>, <code>superficie</code>, <code>anyReforma</code>) amb <code>dadesEnergetiques</code> nested. Conté tota la lògica <code>update_or_create</code>:
<ul>
<li>Si <code>dadesEnergetiques</code> no ve al payload → no es toca res.</li>
<li>Si ve i ja existeixen → s'actualitzen.</li>
<li>Si ve i <strong>no</strong> existeixen → es creen i es vinculen a l'habitatge dins d'un <code>transaction.atomic()</code>.</li>
</ul>
</li>
</ul>
<h3><code>views.py</code></h3>
<ul>
<li><strong><code>me_habitatge</code> action</strong> al <code>EdificiViewSet</code> — <code>PATCH</code> sense restricció per rol (qualsevol usuari autenticat hi pot accedir). Valida la triple relació <code>edifici</code> → <code>habitatge</code> → <code>request.user</code>. Si alguna no es compleix, retorna <code>404</code>.</li>
</ul>
<h2>Detalls tècnics</h2>
<ul>
<li>La URL admet múltiples habitatges per usuari al mateix edifici, identificats per <code>referenciaCadastral</code>.</li>
<li>El recàlcul del BHS i la classificació energètica de l'edifici es dispara automàticament via els signals existents (<code>post_save</code> de <code>DadesEnergetiques</code>), sense cap lògica addicional a la view.</li>
<li><code>select_related('dadesEnergetiques', 'edifici')</code> a la query per evitar N+1.</li>
<li>La resposta retorna l'habitatge complet amb <code>dadesEnergetiques</code> nested (<code>HabitatgeDetailSerializer</code>).</li>
</ul>
<h2>Tests</h2>
<p>Nou fitxer de tests <code>HabitatgeMeUpdateTests</code> amb cobertura de:</p>

Categoria | Casos
-- | --
Autenticació i permisos | 401 sense auth, owner/tenant poden editar el seu, 404 per a altres usuaris, 404 edifici incorrecte, 404 ref cadastral inexistent
Edició camps bàsics | Persistència a BD, payload sense dadesEnergetiques no les toca, resposta conté habitatge complet
Validacions | Superfície negativa, any reforma futur, any reforma anterior a construcció
update_or_create | Crea i vincula quan no existeixen, actualitza sense crear objecte nou, comprova que no queden òrfenes, dades nested a la resposta


<h2>Endpoint</h2>
<pre><code>PATCH /api/buildings/edificis/&lt;id_edifici&gt;/me/habitatge/&lt;referenciaCadastral&gt;/
</code></pre>
<p><strong>Payload exemple:</strong></p>
<pre><code class="language-json">{
  "planta": "2",
  "porta": "1",
  "superficie": 86.5,
  "anyReforma": 2018,
  "dadesEnergetiques": {
    "qualificacioGlobal": "B",
    "consumEnergiaPrimaria": 120.5,
    "dataEntrada": "2026-04-29"
  }
}
</code></pre></body></html><!--EndFragment-->
</body>
</html>