### PR TITLE
Feat: afegeix base backend per xat GetStream

### DIFF
--- a/backend/apps/chat/apps.py
+++ b/backend/apps/chat/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class ChatConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.chat"

--- a/backend/apps/chat/services.py
+++ b/backend/apps/chat/services.py
@@ -1,0 +1,120 @@
+import time
+from typing import Any
+
+import jwt
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from apps.accounts.models import RoleChoices
+from apps.buildings.models import Edifici
+
+
+def get_stream_user_id(user) -> str:
+    """
+    Retorna un identificador estable per a GetStream.
+
+    No fem servir l'email com a identificador principal perquè podria canviar.
+    """
+    return f"user_{user.id}"
+
+
+def create_stream_token_for_user(user) -> str:
+    """
+    Genera un token JWT per connectar l'usuari autenticat a GetStream.
+
+    El secret de Stream només viu al backend. El frontend mai ha de conèixer
+    STREAM_API_SECRET.
+    """
+    if not settings.STREAM_API_SECRET:
+        raise ImproperlyConfigured("STREAM_API_SECRET no està configurat.")
+
+    now = int(time.time())
+    expiration_seconds = int(getattr(settings, "STREAM_TOKEN_EXPIRATION_SECONDS", 3600))
+
+    payload = {
+        "user_id": get_stream_user_id(user),
+        "iat": now,
+        "exp": now + expiration_seconds,
+    }
+
+    return jwt.encode(payload, settings.STREAM_API_SECRET, algorithm="HS256")
+
+
+def get_accessible_buildings(user):
+    """
+    Retorna els edificis als quals l'usuari pot accedir segons la lògica actual.
+
+    En el codi actual:
+    - ADMIN o superuser pot veure tots els edificis actius.
+    - OWNER funciona com a administrador de finca i veu els edificis que gestiona.
+    - TENANT veu edificis on té habitatge vinculat.
+    """
+    if not user.is_authenticated:
+        return Edifici.objects.none()
+
+    role = getattr(getattr(user, "profile", None), "role", None)
+
+    if user.is_superuser or role == RoleChoices.ADMIN:
+        return Edifici.objects.filter(actiu=True).select_related(
+            "grupComparable",
+            "localitzacio",
+        )
+
+    if role == RoleChoices.OWNER:
+        return Edifici.objects.filter(
+            actiu=True,
+            administradorFinca=user,
+        ).select_related(
+            "grupComparable",
+            "localitzacio",
+        )
+
+    return Edifici.objects.filter(
+        actiu=True,
+        habitatges__usuari=user,
+    ).distinct().select_related(
+        "grupComparable",
+        "localitzacio",
+    )
+
+
+def build_channel_descriptors(user) -> list[dict[str, Any]]:
+    """
+    Retorna els canals que el frontend podrà mostrar.
+
+    Aquesta primera PR encara no crea canals reals a GetStream.
+    Només calcula quins canals corresponen a l'usuari autenticat.
+    """
+    buildings = get_accessible_buildings(user)
+    role = getattr(getattr(user, "profile", None), "role", None)
+
+    channels = []
+
+    for edifici in buildings:
+        channels.append({
+            "id": f"building_{edifici.idEdifici}",
+            "type": "messaging",
+            "kind": "building",
+            "name": f"Comunitat edifici {edifici.idEdifici}",
+            "building_id": edifici.idEdifici,
+            "stream_channel_id": f"building_{edifici.idEdifici}",
+            "description": "Xat comunitari intern de l'edifici.",
+        })
+
+        if role in (RoleChoices.ADMIN, RoleChoices.OWNER) and edifici.grupComparable_id:
+            channels.append({
+                "id": f"twin_group_{edifici.grupComparable_id}_admins",
+                "type": "messaging",
+                "kind": "twin_building",
+                "name": f"Twin Building grup {edifici.grupComparable_id}",
+                "group_id": edifici.grupComparable_id,
+                "building_id": edifici.idEdifici,
+                "stream_channel_id": f"twin_group_{edifici.grupComparable_id}_admins",
+                "description": "Xat entre administradors d'edificis similars.",
+            })
+
+    unique_channels = {}
+    for channel in channels:
+        unique_channels[channel["id"]] = channel
+
+    return list(unique_channels.values())

--- a/backend/apps/chat/tests.py
+++ b/backend/apps/chat/tests.py
@@ -1,0 +1,94 @@
+from unittest.mock import patch
+
+import jwt
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.accounts.models import User
+
+
+class ChatTokenTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="chatuser@example.com",
+            password="StrongPass123!",
+        )
+
+    @override_settings(
+        STREAM_API_KEY="test_stream_key",
+        STREAM_API_SECRET="test_stream_secret_for_buildrank_tests_32_chars",
+        STREAM_TOKEN_EXPIRATION_SECONDS=3600,
+    )
+    def test_authenticated_user_can_get_stream_token(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(reverse("chat-token"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["provider"], "getstream")
+        self.assertEqual(response.data["api_key"], "test_stream_key")
+        self.assertEqual(response.data["user_id"], f"user_{self.user.id}")
+        self.assertIn("token", response.data)
+
+        decoded = jwt.decode(
+            response.data["token"],
+            "test_stream_secret_for_buildrank_tests_32_chars",
+            algorithms=["HS256"],
+        )
+        self.assertEqual(decoded["user_id"], f"user_{self.user.id}")
+
+    def test_anonymous_user_cannot_get_stream_token(self):
+        response = self.client.post(reverse("chat-token"))
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @override_settings(
+        STREAM_API_KEY="test_stream_key",
+        STREAM_API_SECRET="",
+        STREAM_TOKEN_EXPIRATION_SECONDS=3600,
+    )
+    def test_missing_stream_secret_returns_503(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(reverse("chat-token"))
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertIn("STREAM_API_SECRET", response.data["detail"])
+
+
+class ChatChannelsTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="channels@example.com",
+            password="StrongPass123!",
+        )
+
+    def test_anonymous_user_cannot_list_channels(self):
+        response = self.client.get(reverse("chat-channels"))
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    @patch("apps.chat.views.build_channel_descriptors")
+    def test_authenticated_user_can_list_channels(self, mocked_builder):
+        mocked_builder.return_value = [
+            {
+                "id": "building_1",
+                "type": "messaging",
+                "kind": "building",
+                "name": "Comunitat edifici 1",
+                "building_id": 1,
+                "stream_channel_id": "building_1",
+                "description": "Xat comunitari intern de l'edifici.",
+            }
+        ]
+
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(reverse("chat-channels"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], "building_1")
+        mocked_builder.assert_called_once_with(self.user)

--- a/backend/apps/chat/urls.py
+++ b/backend/apps/chat/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from .views import ChatChannelsView, ChatTokenView
+
+urlpatterns = [
+    path("token/", ChatTokenView.as_view(), name="chat-token"),
+    path("channels/", ChatChannelsView.as_view(), name="chat-channels"),
+]

--- a/backend/apps/chat/views.py
+++ b/backend/apps/chat/views.py
@@ -1,0 +1,53 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .services import (
+    build_channel_descriptors,
+    create_stream_token_for_user,
+    get_stream_user_id,
+)
+
+
+class ChatTokenView(APIView):
+    """
+    Retorna un token de GetStream per a l'usuari autenticat.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        try:
+            token = create_stream_token_for_user(request.user)
+        except ImproperlyConfigured as exc:
+            return Response(
+                {"detail": str(exc)},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        return Response({
+            "provider": "getstream",
+            "api_key": settings.STREAM_API_KEY,
+            "user_id": get_stream_user_id(request.user),
+            "token": token,
+            "expires_in": settings.STREAM_TOKEN_EXPIRATION_SECONDS,
+        })
+
+
+class ChatChannelsView(APIView):
+    """
+    Retorna els canals de xat accessibles per l'usuari autenticat.
+
+    Aquesta primera versió no sincronitza encara amb GetStream.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        channels = build_channel_descriptors(request.user)
+
+        return Response({
+            "count": len(channels),
+            "results": channels,
+        })

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -79,6 +79,7 @@ INSTALLED_APPS = [
     'apps.seasons',
     'apps.leagues',
     'apps.participations',
+    "apps.chat",
 ]
 
 MIDDLEWARE = [
@@ -262,3 +263,9 @@ CSRF_TRUSTED_ORIGINS = env_list(
 )
 
 CORS_ALLOW_CREDENTIALS = env_bool("CORS_ALLOW_CREDENTIALS", default=True)
+
+
+# GetStream Chat
+STREAM_API_KEY = os.getenv("STREAM_API_KEY", "")
+STREAM_API_SECRET = os.getenv("STREAM_API_SECRET", "")
+STREAM_TOKEN_EXPIRATION_SECONDS = int(os.getenv("STREAM_TOKEN_EXPIRATION_SECONDS", "3600"))

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('api/leagues/', include('apps.leagues.urls')),
     path('api/participations/', include('apps.participations.urls')),
     path('api/third-party-service/', ThirdPartyServiceView.as_view(), name='third-party-service'),
+    path("api/chat/", include("apps.chat.urls")),
 ]
 
 if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
       CSRF_TRUSTED_ORIGINS: "${CSRF_TRUSTED_ORIGINS:-http://localhost,http://127.0.0.1,http://localhost:3000,http://127.0.0.1:3000,http://localhost:5173,http://127.0.0.1:5173,http://localhost:8080,http://127.0.0.1:8080}"
       CORS_ALLOW_ALL_ORIGINS: "${CORS_ALLOW_ALL_ORIGINS:-True}"
       CORS_ALLOW_CREDENTIALS: "${CORS_ALLOW_CREDENTIALS:-True}"
+      STREAM_API_KEY: "${STREAM_API_KEY:-}"
+      STREAM_API_SECRET: "${STREAM_API_SECRET:-}"
+      STREAM_TOKEN_EXPIRATION_SECONDS: "${STREAM_TOKEN_EXPIRATION_SECONDS:-3600}"
       DB_HOST:     db
       DB_PORT:     "5432"
       DB_NAME:     buildrank


### PR DESCRIPTION
## Resum

Aquesta PR introdueix la primera base backend per a l'EPIC 5 - Comunitat i Comunicació, enfocada al xat amb GetStream com a servei extern.

## Canvis principals

- S'ha creat l'app `apps.chat`.
- S'ha afegit l'endpoint `POST /api/chat/token/` per generar un token de GetStream per a l'usuari autenticat.
- S'ha afegit l'endpoint `GET /api/chat/channels/` per retornar els canals accessibles per l'usuari.
- S'han afegit variables de configuració per GetStream:
  - `STREAM_API_KEY`
  - `STREAM_API_SECRET`
  - `STREAM_TOKEN_EXPIRATION_SECONDS`
- S'han afegit tests mínims d'autenticació, generació de token i llistat de canals.

## Decisió tècnica

S'ha escollit GetStream perquè el xat comunitari i el Twin Building requereixen temps real, historial i gestió de canals. Implementar-ho completament amb Django propi afegiria massa risc al Sprint 3. Django continua sent la font de veritat per usuaris, rols, edificis i permisos, mentre que GetStream queda com a servei extern especialitzat en missatgeria.

## Fora d'abast d'aquesta PR

- Connexió Flutter real.
- Creació o sincronització real de canals a GetStream.
- Historial visual.
- Notificacions.
- Moderació.
- OAuth.
- Documentació final del flux.

## Com provar-ho

```bash
python manage.py check
python manage.py test apps.chat -v 2
python manage.py test apps.accounts apps.buildings apps.chat -v 2