### PR TITLE
Refina BHS i simulació de millores per temporades

### DIFF
--- a/backend/apps/buildings/serializers.py
+++ b/backend/apps/buildings/serializers.py
@@ -361,6 +361,11 @@ class RankingSerializer(serializers.ModelSerializer):
         fields = ['idEdifici','puntuacioBase'] #Afegir posició
 
 class CatalegMilloraSerializer(serializers.ModelSerializer):
+    costOrientatiuUnitari = serializers.FloatField(
+        source="cost_orientatiu_unitari",
+        read_only=True,
+    )
+
     class Meta:
         model = CatalegMillora
         fields = [
@@ -372,6 +377,7 @@ class CatalegMilloraSerializer(serializers.ModelSerializer):
             'activa',
             'unitatBase',
             'costEstimatBase',
+            'costOrientatiuUnitari',
             'mantenimentAnual',
             'vidaUtil',
             'estalviEnergeticEstimat',
@@ -400,9 +406,15 @@ class SimulacioMilloraPreviewSerializer(serializers.Serializer):
 
     def validate_millores(self, value):
         if not value:
-            raise serializers.ValidationError("Cal seleccionar com a mínim una millora.")
+            raise serializers.ValidationError("Cal seleccionar com a m?nim una millora.")
 
         ids = [item["milloraId"] for item in value]
+
+        if len(ids) != len(set(ids)):
+            raise serializers.ValidationError(
+                "No es pot seleccionar la mateixa millora m?s d'una vegada en una simulaci?."
+            )
+
         existing_ids = set(
             CatalegMillora.objects
             .filter(idMillora__in=ids, activa=True)
@@ -412,7 +424,7 @@ class SimulacioMilloraPreviewSerializer(serializers.Serializer):
         missing = sorted(set(ids) - existing_ids)
         if missing:
             raise serializers.ValidationError(
-                f"Les millores següents no existeixen o no estan actives: {missing}"
+                f"Les millores seg?ents no existeixen o no estan actives: {missing}"
             )
 
         return value

--- a/backend/apps/buildings/signals.py
+++ b/backend/apps/buildings/signals.py
@@ -15,6 +15,7 @@ def _recalcular_edifici(edifici):
 
     # --- BHS d'habitatges (usuaris) ---
     scores = []
+    score_data_referencia = None
     habitatges = edifici.habitatges.select_related("dadesEnergetiques").all()
 
     for habitatge in habitatges:
@@ -23,10 +24,15 @@ def _recalcular_edifici(edifici):
             continue
         score_data = calcular_building_health_score(dades)
         scores.append(score_data["score"])
+        score_data_referencia = score_data
 
     if scores:
         puntuacio = sum(scores) / len(scores)
-        edifici.bhs_history.create(score=puntuacio, version="1.0", pesos={})
+        edifici.bhs_history.create(
+            score=puntuacio,
+            version=score_data_referencia.get("version", "1.0") if score_data_referencia else "1.0",
+            pesos=score_data_referencia.get("pesos", {}) if score_data_referencia else {},
+        )
         edifici.puntuacioBase = puntuacio
         update_fields.append("puntuacioBase")
 

--- a/backend/apps/buildings/simulation/engine.py
+++ b/backend/apps/buildings/simulation/engine.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import Any, Dict, List
-from django.db.models import Sum
 
 from apps.buildings.models import (
     Edifici,
@@ -11,7 +10,7 @@ from apps.buildings.models import (
 
 MOTOR_VERSION = "SIM-1.0"
 
-# Hipòtesis MVP. No són valors oficials: serveixen com a fallback quan no hi ha dades reals.
+# Hip?tesis MVP. No s?n valors oficials: serveixen com a fallback quan no hi ha dades reals.
 CONSUM_KWH_M2_ANY_FALLBACK = 110.0
 PREU_KWH_FALLBACK = 0.22
 FACTOR_CO2_KG_KWH_FALLBACK = 0.18
@@ -32,20 +31,39 @@ def _num_habitatges(edifici: Edifici) -> int:
 
 def _score_base(edifici: Edifici) -> float:
     """
-    Preferim l'últim BHS si existeix. Si no, usem puntuacioBase.
-    Es limita a 0-100 perquè el motor sigui estable de cara al frontend.
+    Score base utilitzat pel simulador.
+
+    Regla de negoci:
+    - La simulaci? NO modifica puntuacioBase.
+    - El simulador nom?s llegeix el millor score disponible.
+    - Si hi ha historial BHS, es considera la fotografia m?s recent.
+    - Si no hi ha historial, usa puntuacioBase.
+    - Si no hi ha puntuacioBase, usa puntuacioBaseOpenData.
+    - Si tampoc existeix, retorna 0 per no trencar el frontend.
     """
     last_bhs = edifici.bhs_history.first()
     if last_bhs:
         return clamp(last_bhs.score)
 
-    return clamp(edifici.puntuacioBase or 0)
+    if edifici.puntuacioBase is not None:
+        return clamp(edifici.puntuacioBase)
 
+    if getattr(edifici, "puntuacioBaseOpenData", None) is not None:
+        return clamp(edifici.puntuacioBaseOpenData)
+
+    return 0.0
 
 def _dades_base_edifici(edifici: Edifici) -> Dict[str, Any]:
     """
-    Agrega les dades energètiques dels habitatges de l'edifici.
-    Si no hi ha dades energètiques, genera una hipòtesi orientativa per superfície.
+    Agrega les dades energ?tiques de l'edifici per al motor de simulaci?.
+
+    Ordre de prioritat:
+    1. Dades energ?tiques dels habitatges introdu?des pels usuaris.
+    2. Dades Open Data CEE associades a l'edifici.
+    3. Estimaci? MVP per superf?cie.
+
+    Important:
+    Aquest c?lcul nom?s prepara una hip?tesi per simular. No modifica l'edifici.
     """
     habitatges = edifici.habitatges.select_related("dadesEnergetiques").all()
 
@@ -63,7 +81,7 @@ def _dades_base_edifici(edifici: Edifici) -> Dict[str, Any]:
     count = 0
 
     for habitatge in habitatges:
-        dades = habitatge.dadesEnergetiques
+        dades = getattr(habitatge, "dadesEnergetiques", None)
         if not dades:
             continue
 
@@ -113,7 +131,62 @@ def _dades_base_edifici(edifici: Edifici) -> Dict[str, Any]:
             "scoreBase": _score_base(edifici),
         }
 
-    # Fallback quan l'edifici encara no té dades energètiques carregades.
+    # Open Data CEE: millor que una estimaci? gen?rica per superf?cie.
+    od = getattr(edifici, "dades_energetiques_opendata", None)
+    if od is not None:
+        consum_od = od.consumEnergiaFinal or od.consumEnergiaPrimaria or 0
+
+        if consum_od > 0:
+            emissions_od = od.emissionsCO2 or consum_od * FACTOR_CO2_KG_KWH_FALLBACK
+            cost_od = od.costAnualEnergia or consum_od * PREU_KWH_FALLBACK
+
+            serveis_sum = (
+                (od.energiaCalefaccio or 0)
+                + (od.energiaRefrigeracio or 0)
+                + (od.energiaACS or 0)
+                + (od.energiaEnllumenament or 0)
+            )
+
+            if serveis_sum > 0:
+                calefaccio = od.energiaCalefaccio or 0
+                refrigeracio = od.energiaRefrigeracio or 0
+                acs = od.energiaACS or 0
+                enllumenament = od.energiaEnllumenament or 0
+                altres = max(consum_od - serveis_sum, 0)
+            else:
+                calefaccio = consum_od * 0.35
+                refrigeracio = consum_od * 0.15
+                acs = consum_od * 0.20
+                enllumenament = consum_od * 0.10
+                altres = consum_od * 0.20
+
+            return {
+                "origen": "opendata_cee",
+                "num_habitatges_amb_dades": 0,
+                "consumFinalKwhAny": consum_od,
+                "emissionsKgCO2Any": emissions_od,
+                "costAnualEnergia": cost_od,
+                "energiaCalefaccio": calefaccio,
+                "energiaRefrigeracio": refrigeracio,
+                "energiaACS": acs,
+                "energiaEnllumenament": enllumenament,
+                "energiaAltres": altres,
+                "aillamentTermicMitja": od.aillamentTermic or 0,
+                "valorFinestresMitja": od.valorFinestres or 0,
+                "preuKwhEstimatiu": (
+                    cost_od / consum_od
+                    if consum_od > 0 and cost_od > 0
+                    else PREU_KWH_FALLBACK
+                ),
+                "factorCo2KgKwhEstimatiu": (
+                    emissions_od / consum_od
+                    if consum_od > 0 and emissions_od > 0
+                    else FACTOR_CO2_KG_KWH_FALLBACK
+                ),
+                "scoreBase": _score_base(edifici),
+            }
+
+    # Fallback quan l'edifici encara no t? dades energ?tiques carregades.
     superficie = max(edifici.superficieTotal or 0, 1)
     consum_estimat = superficie * CONSUM_KWH_M2_ANY_FALLBACK
 
@@ -142,11 +215,25 @@ def _dades_base_edifici(edifici: Edifici) -> Dict[str, Any]:
     }
 
 
-def _inferir_quantitat(edifici: Edifici, millora: CatalegMillora, quantitat: float | None, cobertura: float) -> float:
+def _inferir_quantitat(
+    edifici: Edifici,
+    millora: CatalegMillora,
+    quantitat: float | None,
+    cobertura: float,
+) -> float:
     """
-    Permet que el frontend no hagi de calcular superfícies o unitats complexes.
-    Si s'envia quantitat, es respecta. Si no, fem una estimació MVP.
+    Permet que el frontend no hagi de calcular superf?cies o unitats complexes.
+
+    Regles:
+    - cobertura 0 => quantitat efectiva 0
+    - quantitat enviada => es respecta, per? no pot ser negativa
+    - quantitat 0 => no genera cost ni impacte
     """
+    cobertura = clamp(cobertura, 0, 100)
+
+    if cobertura == 0:
+        return 0.0
+
     if quantitat is not None:
         return max(float(quantitat), 0)
 
@@ -159,18 +246,26 @@ def _inferir_quantitat(edifici: Edifici, millora: CatalegMillora, quantitat: flo
         return _num_habitatges(edifici) * cobertura_factor
 
     if millora.unitatBase == UnitatBaseMillora.EDIFICI:
-        return 1
+        return 1 * cobertura_factor
 
     if millora.unitatBase == UnitatBaseMillora.KWP:
-        return 3.0
+        return 3.0 * cobertura_factor
 
     if millora.unitatBase == UnitatBaseMillora.KWH:
-        return 5.0
+        return 5.0 * cobertura_factor
 
-    return 1
+    if millora.unitatBase == UnitatBaseMillora.UNITAT:
+        return 1 * cobertura_factor
+
+    return 1 * cobertura_factor
 
 
-def _cost_millora(edifici: Edifici, millora: CatalegMillora, quantitat: float | None, cobertura: float) -> float:
+def _cost_millora(
+    edifici: Edifici,
+    millora: CatalegMillora,
+    quantitat: float | None,
+    cobertura: float,
+) -> float:
     quantitat_final = _inferir_quantitat(edifici, millora, quantitat, cobertura)
     return quantitat_final * (millora.cost_orientatiu_unitari or 0)
 
@@ -183,7 +278,21 @@ def _aplicar_millora(
     quantitat: float | None,
     coberturaPercent: float,
 ) -> Dict[str, Any]:
-    cobertura = clamp(coberturaPercent, 0, 100) / 100
+    cobertura_percent_normalitzada = clamp(coberturaPercent, 0, 100)
+
+    quantitat_final = _inferir_quantitat(
+        edifici,
+        millora,
+        quantitat,
+        cobertura_percent_normalitzada,
+    )
+
+    # Si la quantitat efectiva ?s zero, la millora no ha de generar ni cost ni impacte.
+    if quantitat_final == 0:
+        cobertura = 0.0
+    else:
+        cobertura = cobertura_percent_normalitzada / 100
+
     impactes = millora.parametresBase.get("impactes", {}) if isinstance(millora.parametresBase, dict) else {}
 
     consum_abans = sum(estat.values())
@@ -192,7 +301,7 @@ def _aplicar_millora(
     reduccio_kwh = 0.0
     reduccio_emissions = 0.0
 
-    # Envolupant: calefacció/refrigeració
+    # Envolupant: calefacci?/refrigeraci?.
     reduccio_calefaccio = estat["calefaccio"] * impactes.get("reduccio_demanda_calefaccio", 0) * cobertura
     reduccio_refrigeracio = estat["refrigeracio"] * impactes.get("reduccio_demanda_refrigeracio", 0) * cobertura
     reduccio_infiltracions = (
@@ -202,14 +311,14 @@ def _aplicar_millora(
         * cobertura
     )
 
-    # ACS
+    # ACS.
     reduccio_acs = estat["acs"] * impactes.get("reduccio_demanda_acs", 0) * cobertura
 
-    # Il·luminació
+    # Il?luminaci?.
     reduccio_led = estat["enllumenament"] * impactes.get("reduccio_consum_illuminacio", 0) * cobertura
     reduccio_control = estat["enllumenament"] * impactes.get("reduccio_consum_illuminacio_addicional", 0) * cobertura
 
-    # Reducció elèctrica total genèrica
+    # Reducci? el?ctrica total gen?rica.
     reduccio_total_tipica = consum_abans * impactes.get("reduccio_consum_electric_total_tipica", 0) * cobertura
 
     reduccio_kwh += (
@@ -222,10 +331,10 @@ def _aplicar_millora(
         + reduccio_total_tipica
     )
 
-    # Fotovoltaica: la producció redueix energia de xarxa, no demanda real.
+    # Fotovoltaica: la producci? redueix energia de xarxa, no demanda real.
     produccio_fv = 0.0
     if "produccio_kwh_per_kwp_any" in impactes:
-        kwp = _inferir_quantitat(edifici, millora, quantitat, coberturaPercent)
+        kwp = quantitat_final
         produccio_fv = (
             kwp
             * impactes.get("produccio_kwh_per_kwp_any", 0)
@@ -237,7 +346,7 @@ def _aplicar_millora(
         reduccio_kwh += reduccio_fv
         emissions_factor = impactes.get("co2_evitat_kg_per_kwh_fv", emissions_factor)
 
-    # Aerotèrmia / climatització: tractament simplificat.
+    # Aerot?rmia / climatitzaci?: tractament simplificat.
     reduccio_clima_emissions = 0.0
     if "reduccio_emissions_calefaccio" in impactes:
         reduccio_clima_emissions = (
@@ -253,14 +362,12 @@ def _aplicar_millora(
     reduccio_emissions += reduccio_kwh * emissions_factor
     reduccio_emissions += reduccio_clima_emissions
 
-    # Repartiment simplificat de la reducció sobre categories.
-    # Primer restem de les categories directament afectades.
+    # Repartiment simplificat de la reducci? sobre categories.
     estat["calefaccio"] = max(estat["calefaccio"] - reduccio_calefaccio - reduccio_infiltracions * 0.6, 0)
     estat["refrigeracio"] = max(estat["refrigeracio"] - reduccio_refrigeracio - reduccio_infiltracions * 0.4, 0)
     estat["acs"] = max(estat["acs"] - reduccio_acs, 0)
     estat["enllumenament"] = max(estat["enllumenament"] - reduccio_led - reduccio_control, 0)
 
-    # Si encara queda reducció genèrica/fotovoltaica, la reflectim en altres.
     reduccio_directa = (
         reduccio_calefaccio
         + reduccio_refrigeracio
@@ -272,7 +379,7 @@ def _aplicar_millora(
     restant = max(reduccio_kwh - reduccio_directa, 0)
     estat["altres"] = max(estat["altres"] - restant, 0)
 
-    cost = _cost_millora(edifici, millora, quantitat, coberturaPercent)
+    cost = quantitat_final * (millora.cost_orientatiu_unitari or 0)
     impacte_punts = (millora.impactePunts or 0) * cobertura
 
     return {
@@ -281,8 +388,8 @@ def _aplicar_millora(
         "nom": millora.nom,
         "categoria": millora.categoria,
         "unitatBase": millora.unitatBase,
-        "quantitatAplicada": _round(_inferir_quantitat(edifici, millora, quantitat, coberturaPercent)),
-        "coberturaPercent": _round(coberturaPercent),
+        "quantitatAplicada": _round(quantitat_final),
+        "coberturaPercent": _round(cobertura_percent_normalitzada),
         "costEstimat": _round(cost),
         "reduccioConsumKwhAny": _round(reduccio_kwh),
         "reduccioEmissionsKgCO2Any": _round(reduccio_emissions),
@@ -293,7 +400,7 @@ def _aplicar_millora(
             "motor": MOTOR_VERSION,
             "fontCost": "cataleg_millores_orientatiu",
             "calculExacte": False,
-            "nota": "Estimació MVP. No substitueix auditoria energètica ni pressupost professional.",
+            "nota": "Estimaci? MVP. No substitueix auditoria energ?tica ni pressupost professional.",
         },
     }
 
@@ -305,6 +412,10 @@ def simular_millores(edifici: Edifici, millores_input: List[Dict[str, Any]]) -> 
       {"millora": CatalegMillora, "quantitat": 20, "coberturaPercent": 80},
       ...
     ]
+
+    Important:
+    Aquesta funci? no modifica puntuacioBase ni cap dada real de l'edifici.
+    Nom?s retorna un escenari orientatiu abans/despr?s.
     """
     base = _dades_base_edifici(edifici)
 
@@ -341,6 +452,11 @@ def simular_millores(edifici: Edifici, millores_input: List[Dict[str, Any]]) -> 
         reduccio_total_emissions += parcial["reduccioEmissionsKgCO2Any"]
         impacte_total_punts += parcial["impactePunts"]
 
+    # El delta final retornat al frontend no pot superar l'estat real de partida.
+    # Aix? evita percentatges superiors al 100% en casos extrems o cat?legs mal calibrats.
+    reduccio_total_kwh = min(max(reduccio_total_kwh, 0), base["consumFinalKwhAny"])
+    reduccio_total_emissions = min(max(reduccio_total_emissions, 0), base["emissionsKgCO2Any"])
+
     consum_despres = max(base["consumFinalKwhAny"] - reduccio_total_kwh, 0)
     emissions_despres = max(base["emissionsKgCO2Any"] - reduccio_total_emissions, 0)
     cost_despres = max(base["costAnualEnergia"] - reduccio_total_kwh * base["preuKwhEstimatiu"], 0)
@@ -367,9 +483,17 @@ def simular_millores(edifici: Edifici, millores_input: List[Dict[str, Any]]) -> 
         },
         "delta": {
             "reduccioConsumKwhAny": _round(reduccio_total_kwh),
-            "reduccioConsumPercent": _round((reduccio_total_kwh / base["consumFinalKwhAny"]) * 100 if base["consumFinalKwhAny"] else 0),
+            "reduccioConsumPercent": _round(
+                (reduccio_total_kwh / base["consumFinalKwhAny"]) * 100
+                if base["consumFinalKwhAny"]
+                else 0
+            ),
             "reduccioEmissionsKgCO2Any": _round(reduccio_total_emissions),
-            "reduccioEmissionsPercent": _round((reduccio_total_emissions / base["emissionsKgCO2Any"]) * 100 if base["emissionsKgCO2Any"] else 0),
+            "reduccioEmissionsPercent": _round(
+                (reduccio_total_emissions / base["emissionsKgCO2Any"]) * 100
+                if base["emissionsKgCO2Any"]
+                else 0
+            ),
             "estalviAnualEstimatiu": _round(estalvi_anual),
             "costTotalEstimat": _round(cost_total),
             "incrementScore": _round(score_despres - score_abans),
@@ -379,6 +503,6 @@ def simular_millores(edifici: Edifici, millores_input: List[Dict[str, Any]]) -> 
             "preuKwhEstimatiu": _round(base["preuKwhEstimatiu"]),
             "factorCo2KgKwhEstimatiu": _round(base["factorCo2KgKwhEstimatiu"]),
             "calculExacte": False,
-            "missatge": "Resultat orientatiu basat en paràmetres simplificats i dades disponibles de l'edifici.",
+            "missatge": "Resultat orientatiu basat en par?metres simplificats i dades disponibles de l'edifici.",
         },
     }

--- a/backend/apps/buildings/tests_refinament_simulacio.py
+++ b/backend/apps/buildings/tests_refinament_simulacio.py
@@ -1,0 +1,170 @@
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.accounts.models import RoleChoices
+from apps.buildings.models import (
+    CatalegMillora,
+    DadesEnergetiquesOpenData,
+    Edifici,
+    EstatValidacio,
+    GrupComparable,
+    Localitzacio,
+    MilloraImplementada,
+    UnitatBaseMillora,
+)
+from apps.buildings.serializers import SimulacioMilloraPreviewSerializer
+from apps.buildings.simulation.engine import simular_millores
+
+User = get_user_model()
+
+
+class SimulacioMilloresRefinamentTests(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = User.objects.create_user(
+            email="admin_ref_sim@example.com",
+            password="Password123",
+            first_name="Admin",
+        )
+        cls.admin.profile.role = RoleChoices.ADMIN
+        cls.admin.profile.save(update_fields=["role"])
+
+        cls.grup = GrupComparable.objects.create(
+            idGrup=901,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="0-500",
+        )
+        cls.loc = Localitzacio.objects.create(
+            carrer="Carrer Simulacio Refinada",
+            numero=1,
+            codiPostal="08001",
+            barri="Centre",
+            latitud=41.0,
+            longitud=2.0,
+            zonaClimatica="C2",
+        )
+        cls.edifici = Edifici.objects.create(
+            anyConstruccio=2000,
+            tipologia="Residencial",
+            superficieTotal=400,
+            reglament="CTE",
+            orientacioPrincipal="Sud",
+            localitzacio=cls.loc,
+            administradorFinca=cls.admin,
+            grupComparable=cls.grup,
+        )
+
+        DadesEnergetiquesOpenData.objects.create(
+            edifici=cls.edifici,
+            qualificacioGlobal="D",
+            consumEnergiaPrimaria=9000.0,
+            consumEnergiaFinal=8000.0,
+            emissionsCO2=1600.0,
+            costAnualEnergia=1760.0,
+            energiaCalefaccio=3000.0,
+            energiaRefrigeracio=1000.0,
+            energiaACS=1800.0,
+            energiaEnllumenament=700.0,
+            aillamentTermic=45.0,
+            valorFinestres=2.5,
+        )
+
+        cls.edifici.refresh_from_db()
+        cls.edifici.puntuacioBase = None
+        cls.edifici.puntuacioBaseOpenData = 64.0
+        cls.edifici.save(update_fields=["puntuacioBase", "puntuacioBaseOpenData"])
+
+    @staticmethod
+    def _crear_millora(nom="Millora test", impactes=None, **kwargs):
+        defaults = {
+            "nom": nom,
+            "descripcio": "Millora de prova per al motor de simulació.",
+            "categoria": "envolupant",
+            "unitatBase": UnitatBaseMillora.M2,
+            "costMinim": 1000.0,
+            "costMaxim": 2000.0,
+            "costEstimatBase": 100.0,
+            "estalviEnergeticEstimat": 10.0,
+            "impactePunts": 10.0,
+            "activa": True,
+            "parametresBase": {"impactes": impactes or {}},
+        }
+        defaults.update(kwargs)
+        return CatalegMillora.objects.create(**defaults)
+
+    def test_simulacio_usa_opendata_abans_del_fallback_per_superficie(self):
+        resultat = simular_millores(self.edifici, [])
+
+        self.assertEqual(resultat["abans"]["origenDades"], "opendata_cee")
+        self.assertEqual(resultat["abans"]["consumFinalKwhAny"], 8000.0)
+        self.assertEqual(resultat["abans"]["score"], 64.0)
+
+    def test_quantitat_zero_i_cobertura_positiva_no_generen_impacte(self):
+        millora = self._crear_millora(
+            nom="Millora quantitat zero",
+            impactePunts=25.0,
+            impactes={"reduccio_consum_electric_total_tipica": 0.5},
+        )
+
+        resultat = simular_millores(
+            self.edifici,
+            [{"millora": millora, "quantitat": 0, "coberturaPercent": 100}],
+        )
+
+        self.assertEqual(resultat["delta"]["reduccioConsumKwhAny"], 0.0)
+        self.assertEqual(resultat["delta"]["costTotalEstimat"], 0.0)
+        self.assertEqual(resultat["delta"]["incrementScore"], 0.0)
+
+    def test_percentatge_reduccio_emissions_no_supera_100(self):
+        millora = self._crear_millora(
+            nom="Millora emissions extremes",
+            impactePunts=5.0,
+            impactes={
+                "reduccio_consum_electric_total_tipica": 10.0,
+                "co2_factor_kg_per_kwh_estalviat": 100.0,
+            },
+        )
+
+        resultat = simular_millores(
+            self.edifici,
+            [{"millora": millora, "coberturaPercent": 100}],
+        )
+
+        self.assertLessEqual(resultat["delta"]["reduccioEmissionsPercent"], 100.0)
+        self.assertGreaterEqual(resultat["despres"]["emissionsKgCO2Any"], 0.0)
+
+    def test_serializer_rebutja_millores_duplicades(self):
+        millora = self._crear_millora(nom="Millora duplicada")
+
+        serializer = SimulacioMilloraPreviewSerializer(data={
+            "millores": [
+                {"milloraId": millora.idMillora, "coberturaPercent": 50},
+                {"milloraId": millora.idMillora, "coberturaPercent": 50},
+            ]
+        })
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("mateixa millora", str(serializer.errors))
+
+    def test_validar_millora_no_canvia_puntuacio_base_immediatament(self):
+        millora = self._crear_millora(nom="Millora validada no immediata", impactePunts=20.0)
+
+        implementada = MilloraImplementada.objects.create(
+            dataExecucio="2026-04-01",
+            costReal=1500.0,
+            estatValidacio=EstatValidacio.EN_REVISIO,
+            millora=millora,
+            edifici=self.edifici,
+        )
+
+        self.edifici.puntuacioBase = 64.0
+        self.edifici.save(update_fields=["puntuacioBase"])
+
+        implementada.estatValidacio = EstatValidacio.VALIDADA
+        implementada.administradorFinca = self.admin
+        implementada.save(update_fields=["estatValidacio", "administradorFinca"])
+
+        self.edifici.refresh_from_db()
+        self.assertEqual(self.edifici.puntuacioBase, 64.0)

--- a/backend/apps/seasons/services.py
+++ b/backend/apps/seasons/services.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from django.db import transaction
+from django.db.models import Sum
+
+from apps.buildings.models import Edifici, EstatValidacio, MilloraImplementada
+from .models import Temporada
+
+
+SEASONAL_BHS_VERSION = "SEAS-1.0"
+
+
+def clamp(value: float, minimum: float = 0.0, maximum: float = 100.0) -> float:
+    return max(minimum, min(maximum, value))
+
+
+def _temporada_anterior(temporada: Temporada) -> Optional[Temporada]:
+    return (
+        Temporada.objects
+        .filter(dataFi__lte=temporada.dataInici)
+        .exclude(pk=temporada.pk)
+        .order_by("-dataFi")
+        .first()
+    )
+
+
+def _base_actual(edifici: Edifici) -> float:
+    """
+    Base de partida abans d'aplicar el tancament de la temporada anterior.
+
+    Prioritat:
+    1. puntuacioBase, si ja existeix.
+    2. puntuacioBaseOpenData, si només hi ha dades CEE.
+    3. 0 si no hi ha cap dada encara.
+    """
+    if edifici.puntuacioBase is not None:
+        return float(edifici.puntuacioBase)
+
+    if edifici.puntuacioBaseOpenData is not None:
+        return float(edifici.puntuacioBaseOpenData)
+
+    return 0.0
+
+
+def _bonus_millores_validades(edifici: Edifici, temporada_anterior: Optional[Temporada]) -> float:
+    """
+    Només compten millores implementades i VALIDADA dins la temporada anterior.
+    No es fa servir tota la història de l'edifici.
+    """
+    if temporada_anterior is None:
+        return 0.0
+
+    resultat = (
+        MilloraImplementada.objects
+        .filter(
+            edifici=edifici,
+            estatValidacio=EstatValidacio.VALIDADA,
+            dataExecucio__gte=temporada_anterior.dataInici,
+            dataExecucio__lte=temporada_anterior.dataFi,
+        )
+        .aggregate(total=Sum("millora__impactePunts"))
+    )
+
+    return float(resultat["total"] or 0.0)
+
+
+def _actualitzar_participacions_temporada(temporada: Temporada, edifici: Edifici, puntuacio: float) -> int:
+    """
+    Si ja existeix la participació de l'edifici en la nova temporada, sincronitzem
+    la seva puntuació inicial amb la nova puntuacioBase.
+    """
+    from apps.participations.models import Participacio
+
+    return (
+        Participacio.objects
+        .filter(lliga__temporada=temporada, edifici=edifici)
+        .update(puntuacio=puntuacio)
+    )
+
+
+def _recalcular_posicions_temporada(temporada: Temporada) -> int:
+    """
+    Reordena posicions dins de cada lliga després d'actualitzar puntuacions.
+    """
+    from apps.leagues.models import Lliga
+    from apps.participations.models import Participacio
+
+    actualitzades = 0
+
+    for lliga in Lliga.objects.filter(temporada=temporada):
+        participacions = (
+            Participacio.objects
+            .filter(lliga=lliga)
+            .order_by("-puntuacio", "edifici_id")
+        )
+
+        for index, participacio in enumerate(participacions, start=1):
+            if participacio.posicio != index:
+                participacio.posicio = index
+                participacio.save(update_fields=["posicio"])
+                actualitzades += 1
+
+    return actualitzades
+
+
+def actualitzar_puntuacions_base_inici_temporada(temporada: Temporada) -> Dict[str, object]:
+    """
+    Recalcula la puntuacioBase quan comença una nova temporada.
+
+    Regla de negoci:
+    - Les simulacions no modifiquen puntuacioBase.
+    - Validar una MilloraImplementada tampoc modifica immediatament puntuacioBase.
+    - En iniciar una nova temporada, puntuacioBase = base actual + impacte de millores
+      VALIDADA de la temporada anterior, limitat a 0-100.
+    """
+    temporada_anterior = _temporada_anterior(temporada)
+
+    resum = {
+        "temporada": temporada.id_temporada,
+        "temporada_anterior": temporada_anterior.id_temporada if temporada_anterior else None,
+        "edificis_processats": 0,
+        "edificis_actualitzats": 0,
+        "participacions_actualitzades": 0,
+        "posicions_actualitzades": 0,
+    }
+
+    with transaction.atomic():
+        edificis = Edifici.actius.select_for_update().all()
+
+        for edifici in edificis:
+            resum["edificis_processats"] += 1
+
+            base = _base_actual(edifici)
+            bonus = _bonus_millores_validades(edifici, temporada_anterior)
+            nova_puntuacio = clamp(base + bonus)
+
+            if edifici.puntuacioBase != nova_puntuacio:
+                edifici.puntuacioBase = nova_puntuacio
+                edifici.save(update_fields=["puntuacioBase"])
+                resum["edificis_actualitzats"] += 1
+
+            edifici.bhs_history.create(
+                score=nova_puntuacio,
+                version=SEASONAL_BHS_VERSION,
+                pesos={
+                    "criteri": "inici_temporada",
+                    "base_anterior": round(base, 2),
+                    "bonus_millores_validades_temporada_anterior": round(bonus, 2),
+                    "temporada_anterior": temporada_anterior.id_temporada if temporada_anterior else None,
+                    "nota": (
+                        "La puntuacioBase només es recalcula a l'inici de temporada "
+                        "i només incorpora millores implementades validades de la temporada anterior."
+                    ),
+                },
+            )
+
+            resum["participacions_actualitzades"] += _actualitzar_participacions_temporada(
+                temporada,
+                edifici,
+                nova_puntuacio,
+            )
+
+        resum["posicions_actualitzades"] = _recalcular_posicions_temporada(temporada)
+
+    return resum

--- a/backend/apps/seasons/tests_puntuacio_base_temporada.py
+++ b/backend/apps/seasons/tests_puntuacio_base_temporada.py
@@ -1,0 +1,140 @@
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+from apps.accounts.models import RoleChoices
+from apps.buildings.models import (
+    CatalegMillora,
+    Edifici,
+    EstatValidacio,
+    GrupComparable,
+    Localitzacio,
+    MilloraImplementada,
+)
+from apps.leagues.models import CategoriaRanking, DivisioLliga, Lliga
+from apps.participations.models import Participacio
+from apps.seasons.models import Temporada
+from apps.seasons.services import actualitzar_puntuacions_base_inici_temporada
+
+User = get_user_model()
+
+
+class PuntuacioBaseTemporadaTests(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = User.objects.create_user(
+            email="admin_temp_score@example.com",
+            password="Password123",
+            first_name="Admin",
+        )
+        cls.admin.profile.role = RoleChoices.ADMIN
+        cls.admin.profile.save(update_fields=["role"])
+
+        cls.grup = GrupComparable.objects.create(
+            idGrup=902,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="0-500",
+        )
+        cls.loc = Localitzacio.objects.create(
+            carrer="Carrer Temporada Score",
+            numero=1,
+            codiPostal="08001",
+            barri="Centre",
+            latitud=41.0,
+            longitud=2.0,
+            zonaClimatica="C2",
+        )
+        cls.edifici = Edifici.objects.create(
+            anyConstruccio=2000,
+            tipologia="Residencial",
+            superficieTotal=400,
+            reglament="CTE",
+            orientacioPrincipal="Sud",
+            localitzacio=cls.loc,
+            administradorFinca=cls.admin,
+            grupComparable=cls.grup,
+        )
+        cls.edifici.puntuacioBase = 50.0
+        cls.edifici.save(update_fields=["puntuacioBase"])
+
+        cls.temporada_anterior = Temporada.objects.create(
+            nom="Temporada anterior",
+            dataInici="2026-01-01",
+            dataFi="2026-03-31",
+        )
+        cls.temporada_nova = Temporada.objects.create(
+            nom="Temporada nova",
+            dataInici="2026-04-01",
+            dataFi="2026-06-30",
+        )
+
+        cls.lliga = Lliga.objects.create(
+            nom="Bronze Eficiència",
+            categoria=CategoriaRanking.EFICIENCIA,
+            divisio=DivisioLliga.BRONZE,
+            temporada=cls.temporada_nova,
+        )
+        cls.participacio = Participacio.objects.create(
+            edifici=cls.edifici,
+            lliga=cls.lliga,
+            puntuacio=50.0,
+            posicio=1,
+            divisio="Bronze",
+        )
+
+        cls.millora_validada = CatalegMillora.objects.create(
+            nom="Millora validada temporada anterior",
+            descripcio="Ha de comptar a la temporada següent.",
+            categoria="envolupant",
+            costMinim=1000.0,
+            costMaxim=2000.0,
+            estalviEnergeticEstimat=10.0,
+            impactePunts=7.0,
+            activa=True,
+        )
+        cls.millora_rebutjada = CatalegMillora.objects.create(
+            nom="Millora rebutjada",
+            descripcio="No ha de comptar.",
+            categoria="envolupant",
+            costMinim=1000.0,
+            costMaxim=2000.0,
+            estalviEnergeticEstimat=10.0,
+            impactePunts=90.0,
+            activa=True,
+        )
+
+        MilloraImplementada.objects.create(
+            dataExecucio="2026-02-15",
+            costReal=1500.0,
+            estatValidacio=EstatValidacio.VALIDADA,
+            millora=cls.millora_validada,
+            edifici=cls.edifici,
+            administradorFinca=cls.admin,
+        )
+        MilloraImplementada.objects.create(
+            dataExecucio="2026-02-20",
+            costReal=1500.0,
+            estatValidacio=EstatValidacio.REBUTJADA,
+            millora=cls.millora_rebutjada,
+            edifici=cls.edifici,
+            administradorFinca=cls.admin,
+        )
+
+    def test_inici_temporada_actualitza_base_amb_validada_anterior(self):
+        resum = actualitzar_puntuacions_base_inici_temporada(self.temporada_nova)
+
+        self.edifici.refresh_from_db()
+        self.participacio.refresh_from_db()
+
+        self.assertEqual(self.edifici.puntuacioBase, 57.0)
+        self.assertEqual(self.participacio.puntuacio, 57.0)
+        self.assertEqual(resum["temporada_anterior"], self.temporada_anterior.id_temporada)
+        self.assertGreaterEqual(resum["edificis_actualitzats"], 1)
+
+    def test_millores_no_validades_no_compten(self):
+        actualitzar_puntuacions_base_inici_temporada(self.temporada_nova)
+
+        self.edifici.refresh_from_db()
+
+        self.assertNotEqual(self.edifici.puntuacioBase, 140.0)
+        self.assertEqual(self.edifici.puntuacioBase, 57.0)

--- a/backend/apps/seasons/views.py
+++ b/backend/apps/seasons/views.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import NotFound
 from apps.accounts.permissions import IsAdminSistema
 from .models import Temporada
 from .serializers import TemporadaSerializer
+from .services import actualitzar_puntuacions_base_inici_temporada
 from apps.participations.models import Participacio
 from apps.participations.serializers import RankingSerializer
 from apps.leagues.models import Lliga
@@ -32,9 +33,14 @@ class TemporadaViewSet(viewsets.ModelViewSet):
         temporada = self.get_object()
         try:
             Temporada.objects.iniciar(temporada)
+            resum_puntuacions = actualitzar_puntuacions_base_inici_temporada(temporada)
+            temporada.refresh_from_db()
         except ValueError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
-        return Response(TemporadaSerializer(temporada).data)
+
+        data = TemporadaSerializer(temporada).data
+        data["resum_puntuacions_base"] = resum_puntuacions
+        return Response(data)
 
     @action(detail=True, methods=['post'], url_path='tancar')
     def tancar(self, request, pk=None):


### PR DESCRIPTION
## Resum

Aquest PR refina la coherència entre el motor de simulació de millores, la puntuació base de l’edifici i el funcionament per temporades.

L’objectiu principal és deixar clara la separació entre:

- `puntuacioBase`: puntuació base de partida de l’edifici per a una temporada.
- Simulacions de millores: escenaris hipotètics que no modifiquen dades reals.
- Millores implementades validades: millores reals que només afecten la puntuació base quan s’inicia una nova temporada.
- Open Data CEE: dades utilitzables pel simulador quan encara no hi ha dades energètiques d’habitatges.

## Canvis principals

### Simulació de millores

- El motor de simulació continua sense modificar `puntuacioBase`.
- El simulador ara prioritza les dades en aquest ordre:
  1. Dades energètiques dels habitatges.
  2. Dades Open Data CEE de l’edifici.
  3. Fallback MVP per superfície.
- El score base del simulador manté compatibilitat amb el comportament existent:
  1. Últim BHS històric.
  2. `puntuacioBase`.
  3. `puntuacioBaseOpenData`.
  4. `0` si no hi ha dades.
- S’evita que una millora amb `quantitat = 0` generi impacte, cost o increment de score.
- Les reduccions totals de consum i emissions queden limitades perquè no superin el 100% de l’estat inicial.
- Es manté la resposta `abans`, `despres`, `delta`, `items` i `hipotesis`.

### Serializer i API

- El serializer de simulació rebutja millores duplicades dins d’una mateixa simulació.
- El catàleg de millores exposa `costOrientatiuUnitari`, que representa el cost unitari real que utilitza el motor quan calcula costos.
- No s’han eliminat camps existents de la resposta, per tant el canvi és compatible amb el frontend actual.

### Temporades i puntuació base

- S’ha afegit un servei d’inici de temporada per actualitzar `puntuacioBase`.
- La validació d’una `MilloraImplementada` no modifica immediatament la puntuació base.
- Quan s’inicia una nova temporada, es recalcula la puntuació base incorporant només les millores implementades i validades de la temporada anterior.
- Si ja hi ha participacions creades per a la nova temporada, se sincronitzen amb la nova `puntuacioBase`.
- També es recalculen les posicions de les participacions dins de cada lliga.

## Decisió funcional

La `puntuacioBase` representa la base de partida d’una temporada.  
Les simulacions no alteren aquesta puntuació.  
Les millores implementades validades tampoc l’alteren immediatament durant la temporada activa.  
El seu impacte s’incorpora de forma ordenada quan comença la temporada següent.

Això evita que la puntuació base canviï constantment durant una temporada i manté el sistema coherent amb el model de competició per temporades.

## Tests afegits

S’han afegit tests per validar:

- Que el simulador utilitza Open Data CEE abans del fallback per superfície.
- Que `quantitat = 0` no genera impacte.
- Que les reduccions d’emissions no superen el 100%.
- Que el serializer rebutja millores duplicades.
- Que validar una millora no canvia `puntuacioBase` immediatament.
- Que l’inici d’una nova temporada actualitza `puntuacioBase` amb les millores validades de la temporada anterior.
- Que les millores no validades o rebutjades no compten.

## Validació realitzada

S’han executat les comprovacions següents:

```bash
docker compose exec web python manage.py makemigrations --check --dry-run
docker compose exec web python manage.py check
docker compose exec web python manage.py migrate --plan
docker compose exec web python manage.py test apps.buildings apps.seasons -v 2