### PR TITLE
Afegit endpoint de GEOJson per construir mapa

### DIFF
--- a/backend/apps/buildings/serializers.py
+++ b/backend/apps/buildings/serializers.py
@@ -220,6 +220,86 @@ class EdificiListSerializer(serializers.ModelSerializer):
         model = Edifici
         fields = ['idEdifici', 'tipologia', 'anyConstruccio', 'superficieTotal', 'puntuacioBase']
 
+class EdificiMapSerializer(serializers.ModelSerializer):
+    """
+    Serializer lleuger per representar edificis al mapa en format GeoJSON.
+
+    No exposa dades personals, habitatges ni informació sensible.
+    Només retorna dades agregades i visuals de l'edifici.
+    """
+    type = serializers.SerializerMethodField()
+    id = serializers.IntegerField(source="idEdifici", read_only=True)
+    geometry = serializers.SerializerMethodField()
+    properties = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Edifici
+        fields = ["type", "id", "geometry", "properties"]
+
+    def get_type(self, obj):
+        return "Feature"
+
+    def get_geometry(self, obj):
+        loc = obj.localitzacio
+
+        return {
+            "type": "Point",
+            "coordinates": [
+                loc.longitud,
+                loc.latitud,
+            ],
+        }
+
+    def get_properties(self, obj):
+        loc = obj.localitzacio
+
+        score = obj.puntuacioBase
+        if score is None:
+            score = obj.puntuacioBaseOpenData
+
+        score_label = self._score_label(score)
+
+        carrer = (loc.carrer or "").strip()
+        numero = loc.numero
+        barri = (loc.barri or "").strip()
+        codi_postal = (loc.codiPostal or "").strip()
+
+        titol = f"{carrer}, {numero}" if carrer else f"Edifici {obj.idEdifici}"
+
+        adreca_parts = [
+            titol,
+            barri,
+            codi_postal,
+        ]
+
+        return {
+            "idEdifici": obj.idEdifici,
+            "titol": titol,
+            "adreca": " · ".join([part for part in adreca_parts if part]),
+            "barri": barri,
+            "codiPostal": codi_postal,
+            "tipologia": obj.tipologia,
+            "anyConstruccio": obj.anyConstruccio,
+            "superficieTotal": obj.superficieTotal,
+            "puntuacioBase": round(score, 2) if score is not None else None,
+            "puntuacioLabel": score_label,
+            "classificacioEstimada": obj.classificacioEstimada,
+            "classificacioFont": obj.classificacioFont,
+            "fontOpenData": obj.font_open_data,
+            "detailEndpoint": f"/api/buildings/edificis/{obj.idEdifici}/",
+        }
+
+    def _score_label(self, score):
+        if score is None:
+            return "SENSE_DADES"
+        if score >= 80:
+            return "EXCEL·LENT"
+        if score >= 65:
+            return "BO"
+        if score >= 50:
+            return "MILLORABLE"
+        return "PRIORITARI"
+
 def _etiqueta_font(font: str | None) -> str:
     """Retorna una etiqueta llegible per a la UI segons l'origen de la classificació."""
     etiquetes = {

--- a/backend/apps/buildings/tests.py
+++ b/backend/apps/buildings/tests.py
@@ -3161,6 +3161,105 @@ class HabitatgeMeUpdateTests(BaseTestData):
         )
 
 
+class EdificiMapaEndpointTests(BaseTestData):
+    """Tests de l'endpoint GeoJSON per al mapa d'edificis."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = cls._create_user("map-admin@example.com", RoleChoices.ADMIN)
+
+        cls.grup = GrupComparable.objects.create(
+            idGrup=99,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="100-200",
+        )
+
+        cls.edifici_visible = cls._create_edifici(
+            administrador=cls.admin,
+            grup=cls.grup,
+            carrer="Carrer Mallorca",
+            numero=120,
+        )
+        cls.edifici_visible.puntuacioBase = 72.5
+        cls.edifici_visible.classificacioEstimada = "C"
+        cls.edifici_visible.classificacioFont = "estimada"
+        cls.edifici_visible.save(
+            update_fields=[
+                "puntuacioBase",
+                "classificacioEstimada",
+                "classificacioFont",
+            ]
+        )
+
+        cls.edifici_sense_coords = cls._create_edifici(
+            administrador=cls.admin,
+            grup=cls.grup,
+            carrer="Carrer Sense Coordenades",
+            numero=1,
+        )
+        cls.edifici_sense_coords.localitzacio.latitud = 0.0
+        cls.edifici_sense_coords.localitzacio.longitud = 0.0
+        cls.edifici_sense_coords.localitzacio.save(
+            update_fields=["latitud", "longitud"]
+        )
+
+    def test_mapa_requires_authentication(self):
+        response = self.client.get("/api/buildings/edificis/mapa/")
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_mapa_returns_geojson_feature_collection(self):
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get("/api/buildings/edificis/mapa/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["type"], "FeatureCollection")
+        self.assertIn("features", response.data)
+        self.assertGreaterEqual(len(response.data["features"]), 1)
+
+        feature = response.data["features"][0]
+        self.assertEqual(feature["type"], "Feature")
+        self.assertEqual(feature["geometry"]["type"], "Point")
+        self.assertIn("coordinates", feature["geometry"])
+        self.assertIn("properties", feature)
+
+    def test_mapa_excludes_buildings_without_valid_coordinates(self):
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get("/api/buildings/edificis/mapa/")
+
+        ids = [
+            feature["properties"]["idEdifici"]
+            for feature in response.data["features"]
+        ]
+
+        self.assertIn(self.edifici_visible.idEdifici, ids)
+        self.assertNotIn(self.edifici_sense_coords.idEdifici, ids)
+
+    def test_mapa_does_not_expose_private_user_or_habitatge_data(self):
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get("/api/buildings/edificis/mapa/")
+
+        feature = response.data["features"][0]
+        properties = feature["properties"]
+
+        self.assertNotIn("habitatges", properties)
+        self.assertNotIn("usuari", properties)
+        self.assertNotIn("administradorFinca", properties)
+        self.assertNotIn("email", properties)
+
+    def test_mapa_bbox_filter(self):
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.get(
+            "/api/buildings/edificis/mapa/?bbox=1.9,40.9,2.1,41.1"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 # ============================================================================
 # THIRD PARTY SERVICE — POST /api/third-party/score/
 # ============================================================================

--- a/backend/apps/buildings/views.py
+++ b/backend/apps/buildings/views.py
@@ -21,7 +21,7 @@ from .models import (
     CatalegMillora, SimulacioMillora, SimulacioMilloraItem, MilloraImplementada,
 )
 from .serializers import (
-    EdificiDetailSerializer, EdificiListSerializer,
+    EdificiDetailSerializer, EdificiListSerializer, EdificiMapSerializer,
     HabitatgeDetailSerializer, HabitatgeMeUpdateSerializer, HabitatgeResumSerializer,
     LocalitzacioSerializer, DadesEnergetiquesSerializer,
     RankingSerializer,
@@ -514,6 +514,131 @@ class EdificiViewSet(viewsets.ModelViewSet):
 
         serializer = MilloraImplementadaSerializer(implementacions, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
+    
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="mapa",
+        permission_classes=[IsAuthenticated],
+    )
+    def mapa(self, request):
+        """
+        GET /api/buildings/edificis/mapa/
+
+        Retorna els edificis actius amb coordenades vàlides en format GeoJSON.
+
+        Query params opcionals:
+        - scope=public|mine
+        - bbox=minLng,minLat,maxLng,maxLat
+        - tipologia=Residencial
+        - score_min=60
+        - q=text
+        - limit=500
+        """
+        scope = request.query_params.get("scope", "public").lower().strip()
+
+        if scope == "mine":
+            queryset = self.get_queryset()
+        else:
+            queryset = Edifici.actius.all()
+
+        queryset = (
+            queryset
+            .select_related("localitzacio", "grupComparable")
+            .filter(
+                localitzacio__isnull=False,
+                localitzacio__latitud__isnull=False,
+                localitzacio__longitud__isnull=False,
+            )
+            .exclude(localitzacio__latitud=0.0)
+            .exclude(localitzacio__longitud=0.0)
+        )
+
+        tipologia = request.query_params.get("tipologia")
+        if tipologia:
+            queryset = queryset.filter(tipologia=tipologia)
+
+        search = request.query_params.get("q", "").strip()
+        if search:
+            queryset = queryset.filter(
+                Q(localitzacio__carrer__icontains=search)
+                | Q(localitzacio__barri__icontains=search)
+                | Q(localitzacio__codiPostal__icontains=search)
+            )
+
+        score_min_raw = request.query_params.get("score_min")
+        if score_min_raw:
+            try:
+                score_min = float(score_min_raw)
+            except ValueError:
+                return Response(
+                    {"detail": "El paràmetre score_min ha de ser numèric."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            queryset = queryset.filter(
+                Q(puntuacioBase__gte=score_min)
+                | Q(puntuacioBaseOpenData__gte=score_min)
+            )
+
+        bbox_raw = request.query_params.get("bbox")
+        if bbox_raw:
+            try:
+                min_lng, min_lat, max_lng, max_lat = [
+                    float(value.strip())
+                    for value in bbox_raw.split(",")
+                ]
+            except ValueError:
+                return Response(
+                    {
+                        "detail": (
+                            "El paràmetre bbox ha de tenir el format "
+                            "minLng,minLat,maxLng,maxLat."
+                        )
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            queryset = queryset.filter(
+                localitzacio__longitud__gte=min_lng,
+                localitzacio__longitud__lte=max_lng,
+                localitzacio__latitud__gte=min_lat,
+                localitzacio__latitud__lte=max_lat,
+            )
+
+        limit_raw = request.query_params.get("limit", "500")
+        try:
+            limit = int(limit_raw)
+        except ValueError:
+            return Response(
+                {"detail": "El paràmetre limit ha de ser un enter."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        limit = max(1, min(limit, 1000))
+
+        total = queryset.count()
+        queryset = queryset.order_by("idEdifici")[:limit]
+
+        serializer = EdificiMapSerializer(
+            queryset,
+            many=True,
+            context={"request": request},
+        )
+
+        return Response(
+            {
+                "type": "FeatureCollection",
+                "count": total,
+                "features": serializer.data,
+                "meta": {
+                    "scope": scope,
+                    "limit": limit,
+                    "truncated": total > limit,
+                },
+            },
+            status=status.HTTP_200_OK,
+        )
 
 
 class MilloraImplementadaViewSet(viewsets.GenericViewSet):


### PR DESCRIPTION
# feat(buildings): afegir endpoint GeoJSON per al mapa d’edificis

## Resum

Aquest PR afegeix la primera integració backend per poder representar els edificis registrats de BuildRank en un mapa.

S’ha incorporat un nou endpoint:

`GET /api/buildings/edificis/mapa/`

Aquest endpoint retorna els edificis actius amb coordenades vàlides en format **GeoJSON**, de manera que el frontend pugui pintar-los posteriorment sobre un mapa amb una llibreria com `flutter_map` i una capa de mapa basada en OpenStreetMap o equivalent.

La funcionalitat s’ha implementat només al backend en aquest PR. La integració visual al frontend es farà en una PR posterior.

---

## Motivació

Aquesta funcionalitat neix com una millora suggerida durant la revisió del projecte. Tot i que no estava prevista inicialment com una funcionalitat principal del MVP, encaixa molt bé amb la naturalesa de BuildRank.

BuildRank treballa amb:

- edificis registrats
- localitzacions
- puntuacions energètiques
- classificació energètica estimada
- comparatives territorials
- dades obertes vinculades al parc residencial

Per tant, un mapa permet representar aquesta informació de manera més visual i professional. No es tracta només d’afegir un mapa decoratiu, sinó de donar una nova forma de consultar i entendre les dades del sistema.

Amb aquesta API, el frontend podrà mostrar els edificis sobre un mapa i ensenyar estadístiques bàsiques de cada edifici, com la puntuació, la classificació estimada, la tipologia o l’adreça resumida.

---

## Decisió tècnica

S’ha decidit que el backend exposi les dades geogràfiques en format **GeoJSON**.

Aquesta decisió és adequada perquè:

- GeoJSON és un format estàndard per representar dades geogràfiques.
- És fàcil de consumir des de Flutter.
- Evita acoblar el backend a Google Maps, Mapbox o qualsevol altre proveïdor concret.
- Permet canviar la capa visual del mapa sense modificar la lògica del backend.
- Manté Django REST Framework com a font de veritat de les dades del producte.
- Facilita una futura evolució cap a filtres, clustering, capes o altres visualitzacions.

El backend no renderitza cap mapa ni depèn d’una API externa de mapes. Només exposa les dades dels edificis en un format preparat perquè el frontend les pugui representar.

---

## Nou endpoint

### `GET /api/buildings/edificis/mapa/`

Retorna una `FeatureCollection` GeoJSON amb els edificis actius que tenen coordenades vàlides.

Exemple de resposta:

```json
{
  "type": "FeatureCollection",
  "count": 1,
  "features": [
    {
      "type": "Feature",
      "id": 54,
      "geometry": {
        "type": "Point",
        "coordinates": [
          2.1599,
          41.3891
        ]
      },
      "properties": {
        "idEdifici": 54,
        "titol": "Carrer Mallorca, 120",
        "adreca": "Carrer Mallorca, 120 · Eixample · 08036",
        "barri": "Eixample",
        "codiPostal": "08036",
        "tipologia": "Residencial",
        "anyConstruccio": 1978,
        "superficieTotal": 850.0,
        "puntuacioBase": 72.5,
        "puntuacioLabel": "BO",
        "classificacioEstimada": "C",
        "classificacioFont": "estimada",
        "fontOpenData": true,
        "detailEndpoint": "/api/buildings/edificis/54/"
      }
    }
  ],
  "meta": {
    "scope": "public",
    "limit": 500,
    "truncated": false
  }
}
```
