### PR TITLE
feat(accounts): suport de rol en el registre OAuth amb Google

### DIFF
--- a/backend/apps/accounts/serializers.py
+++ b/backend/apps/accounts/serializers.py
@@ -384,6 +384,7 @@ class PasswordResetConfirmSerializer(serializers.Serializer):
 
 class GoogleOAuthSerializer(serializers.Serializer):
     id_token = serializers.CharField(write_only=True)
+    role = serializers.ChoiceField(choices=RoleChoices.choices, required=False)
 
     def validate(self, attrs):
         token = attrs["id_token"]
@@ -445,8 +446,13 @@ class GoogleOAuthSerializer(serializers.Serializer):
 
         profile, _ = Profile.objects.get_or_create(user=user)
         if created:
-            profile.role = RoleChoices.OWNER
+            profile.role = self.validated_data.get(
+                "role",
+                RoleChoices.OWNER,
+            )
             profile.save(update_fields=["role"])
+        
+        user.profile.refresh_from_db()
 
         refresh = RefreshToken.for_user(user)
         jti = str(refresh.get("jti"))

--- a/backend/apps/accounts/tests.py
+++ b/backend/apps/accounts/tests.py
@@ -1396,3 +1396,119 @@ class GoogleOAuthTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("detail", response.data)
+        
+    @patch("apps.accounts.serializers.google_id_token.verify_oauth2_token")
+    def test_google_oauth_creates_user_with_requested_role(
+        self,
+        mock_verify,
+    ):
+        mock_verify.return_value = {
+            "email": "tenant-google@example.com",
+            "email_verified": True,
+            "given_name": "Tenant",
+            "family_name": "Google",
+        }
+
+        response = self.client.post(
+            self.url,
+            {
+                "id_token": "valid-google-id-token",
+                "role": RoleChoices.TENANT,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("access", response.data)
+        self.assertIn("refresh", response.data)
+        self.assertEqual(
+            response.data["user"]["email"],
+            "tenant-google@example.com",
+        )
+        self.assertEqual(
+            response.data["user"]["role"],
+            RoleChoices.TENANT,
+        )
+
+        user = User.objects.get(email="tenant-google@example.com")
+        self.assertEqual(user.profile.role, RoleChoices.TENANT)
+
+    @patch("apps.accounts.serializers.google_id_token.verify_oauth2_token")
+    def test_google_oauth_existing_user_does_not_change_role(
+        self,
+        mock_verify,
+    ):
+        existing_user = User.objects.create_user(
+            email="existing-role@example.com",
+            password="Password123",
+            first_name="Existing",
+            last_name="Role",
+        )
+
+        existing_user.profile.role = RoleChoices.OWNER
+        existing_user.profile.save(update_fields=["role"])
+
+        mock_verify.return_value = {
+            "email": "existing-role@example.com",
+            "email_verified": True,
+            "given_name": "GoogleName",
+            "family_name": "GoogleSurname",
+        }
+
+        response = self.client.post(
+            self.url,
+            {
+                "id_token": "valid-google-id-token",
+                "role": RoleChoices.TENANT,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        existing_user.refresh_from_db()
+        existing_user.profile.refresh_from_db()
+
+        self.assertEqual(
+            existing_user.profile.role,
+            RoleChoices.OWNER,
+        )
+
+        self.assertEqual(
+            response.data["user"]["role"],
+            RoleChoices.OWNER,
+        )
+
+    @patch("apps.accounts.serializers.google_id_token.verify_oauth2_token")
+    def test_google_oauth_rejects_invalid_role(
+        self,
+        mock_verify,
+    ):
+        mock_verify.return_value = {
+            "email": "invalid-role-google@example.com",
+            "email_verified": True,
+            "given_name": "Invalid",
+            "family_name": "Role",
+        }
+
+        response = self.client.post(
+            self.url,
+            {
+                "id_token": "valid-google-id-token",
+                "role": "superadmin",
+            },
+            format="json",
+        )
+
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_400_BAD_REQUEST,
+        )
+
+        self.assertIn("role", response.data)
+
+        self.assertFalse(
+            User.objects.filter(
+                email="invalid-role-google@example.com"
+            ).exists()
+        )


### PR DESCRIPTION
## Resum

Aquesta PR amplia la integració OAuth amb Google per permetre enviar un `role` opcional durant el registre d’usuaris nous des del frontend.

## Canvis implementats

- Afegit suport per al camp opcional `role` a `GoogleOAuthSerializer`
- Els usuaris nous creats via Google OAuth poden inicialitzar-se amb:
  - `owner`
  - `tenant`
  - `admin`
- Si no s’envia cap rol, es manté el comportament per defecte (`owner`)
- Els usuaris existents NO modifiquen el seu rol encara que s’enviï un `role`
- Afegits tests automatitzats per validar:
  - creació amb rol personalitzat
  - preservació del rol en usuaris existents
  - rebuig de rols invàlids

## Tests executats

```bash
python3 backend/manage.py test apps.accounts.tests.GoogleOAuthTests