### PR TITLE
Afegeix xat Twin Building entre administradors

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Run tests with coverage
         run: |
           pip install coverage
-          coverage run manage.py test apps.accounts apps.buildings apps.leagues apps.seasons apps.participations apps.verification -v 2
+          coverage run manage.py test apps.accounts apps.buildings apps.leagues apps.seasons apps.participations apps.verification apps.chat -v 2
           coverage report --ignore-errors
           coverage xml --ignore-errors
 

--- a/backend/apps/chat/services.py
+++ b/backend/apps/chat/services.py
@@ -301,3 +301,220 @@ def validate_twin_channel_access(user, group_id: int) -> bool:
     if role == RoleChoices.TENANT and not user.is_superuser:
         return False
     return get_accessible_buildings(user).filter(grupComparable_id=group_id).exists()
+
+def _format_building_address(edifici) -> str:
+    loc = getattr(edifici, "localitzacio", None)
+    if not loc:
+        return f"Edifici {edifici.idEdifici}"
+
+    parts = []
+    if loc.carrer:
+        parts.append(str(loc.carrer))
+    if loc.numero is not None:
+        parts.append(str(loc.numero))
+
+    address = " ".join(parts).strip()
+    return address or f"Edifici {edifici.idEdifici}"
+
+
+def _format_user_name(user) -> str:
+    full_name = f"{user.first_name} {user.last_name}".strip()
+    return full_name or user.email
+
+
+def _is_admin_finca_of_building(user, edifici) -> bool:
+    if not user.is_authenticated:
+        return False
+
+    if user.is_superuser:
+        return True
+
+    role = getattr(getattr(user, "profile", None), "role", None)
+    return role == RoleChoices.ADMIN and edifici.administradorFinca_id == user.id
+
+
+def _is_valid_target_admin(user) -> bool:
+    if user is None:
+        return False
+
+    if user.is_superuser:
+        return True
+
+    role = getattr(getattr(user, "profile", None), "role", None)
+    return role == RoleChoices.ADMIN
+
+
+def _build_twin_admin_descriptor(edifici) -> dict[str, Any]:
+    admin = edifici.administradorFinca
+    loc = getattr(edifici, "localitzacio", None)
+
+    return {
+        "edifici_id": edifici.idEdifici,
+        "adreca": _format_building_address(edifici),
+        "barri": getattr(loc, "barri", "") if loc else "",
+        "codiPostal": getattr(loc, "codiPostal", "") if loc else "",
+        "zonaClimatica": getattr(loc, "zonaClimatica", "") if loc else "",
+        "tipologia": edifici.tipologia,
+        "superficieTotal": edifici.superficieTotal,
+        "puntuacioBase": edifici.puntuacioBase,
+        "grupComparable": edifici.grupComparable_id,
+        "admin": {
+            "id": admin.id,
+            "stream_user_id": get_stream_user_id(admin),
+            "email": admin.email,
+            "name": _format_user_name(admin),
+        },
+    }
+
+
+def get_twin_building_admin_candidates(user, edifici_id: int) -> list[dict[str, Any]]:
+    """
+    Retorna administradors de finca d'edificis comparables al de partida.
+
+    Regles:
+    - L'usuari ha de ser l'administrador de finca de l'edifici origen.
+    - L'edifici origen ha de tenir GrupComparable.
+    - Només es retornen edificis actius del mateix grup.
+    - No es retorna el propi edifici.
+    - No es retorna el mateix administrador.
+    - Només es retornen edificis amb administrador de finca vàlid.
+    """
+    try:
+        source = (
+            Edifici.objects
+            .select_related("localitzacio", "grupComparable", "administradorFinca__profile")
+            .get(pk=edifici_id, actiu=True)
+        )
+    except Edifici.DoesNotExist as exc:
+        raise ValueError("No s'ha trobat l'edifici origen.") from exc
+
+    if not _is_admin_finca_of_building(user, source):
+        raise PermissionError(
+            "Només l'administrador de finca d'aquest edifici pot consultar edificis comparables."
+        )
+
+    if not source.grupComparable_id:
+        return []
+
+    candidates = (
+        Edifici.objects
+        .filter(
+            actiu=True,
+            grupComparable_id=source.grupComparable_id,
+            administradorFinca__isnull=False,
+        )
+        .exclude(pk=source.pk)
+        .exclude(administradorFinca_id=user.id)
+        .select_related("localitzacio", "grupComparable", "administradorFinca__profile")
+        .order_by("idEdifici")
+    )
+
+    results: list[dict[str, Any]] = []
+    for edifici in candidates:
+        if _is_valid_target_admin(edifici.administradorFinca):
+            results.append(_build_twin_admin_descriptor(edifici))
+
+    return results
+
+
+def get_or_create_twin_building_admin_channel(
+    user,
+    source_edifici_id: int,
+    target_edifici_id: int,
+) -> dict[str, Any]:
+    """
+    Crea o obté un canal directe entre dos administradors de finca
+    d'edificis del mateix GrupComparable.
+    """
+    try:
+        source = (
+            Edifici.objects
+            .select_related("localitzacio", "grupComparable", "administradorFinca__profile")
+            .get(pk=source_edifici_id, actiu=True)
+        )
+    except Edifici.DoesNotExist as exc:
+        raise ValueError("No s'ha trobat l'edifici origen.") from exc
+
+    if not _is_admin_finca_of_building(user, source):
+        raise PermissionError(
+            "Només l'administrador de finca d'aquest edifici pot crear el xat Twin Building."
+        )
+
+    if not source.grupComparable_id:
+        raise ValueError("L'edifici origen no té cap grup comparable assignat.")
+
+    try:
+        target = (
+            Edifici.objects
+            .select_related("localitzacio", "grupComparable", "administradorFinca__profile")
+            .get(pk=target_edifici_id, actiu=True)
+        )
+    except Edifici.DoesNotExist as exc:
+        raise ValueError("No s'ha trobat l'edifici destí.") from exc
+
+    if target.pk == source.pk:
+        raise ValueError("No es pot crear un xat Twin Building amb el mateix edifici.")
+
+    if target.grupComparable_id != source.grupComparable_id:
+        raise ValueError("L'edifici destí no pertany al mateix grup comparable.")
+
+    target_admin = target.administradorFinca
+    if not _is_valid_target_admin(target_admin):
+        raise ValueError("L'edifici destí no té un administrador de finca vàlid.")
+
+    if target_admin.id == user.id:
+        raise ValueError("No es pot crear un xat Twin Building amb un edifici gestionat pel mateix usuari.")
+
+    client = get_stream_client()
+
+    source_stream_uid = get_stream_user_id(user)
+    target_stream_uid = get_stream_user_id(target_admin)
+
+    sync_user_to_stream(client, user)
+    sync_user_to_stream(client, target_admin)
+
+    source_id = int(source.idEdifici)
+    target_id = int(target.idEdifici)
+    low_id = min(source_id, target_id)
+    high_id = max(source_id, target_id)
+
+    channel_id = f"twin_building_{low_id}_{high_id}_admins"
+    channel_name = f"Twin Building: {_format_building_address(source)} ↔ {_format_building_address(target)}"
+
+    channel = client.channel(
+        "messaging",
+        channel_id,
+        data={
+            "name": channel_name,
+            "kind": "twin_building_direct",
+            "source_edifici_id": source.idEdifici,
+            "target_edifici_id": target.idEdifici,
+            "grup_comparable_id": source.grupComparable_id,
+        },
+    )
+    channel.create(source_stream_uid)
+    channel.add_members([source_stream_uid, target_stream_uid])
+
+    return {
+        "id": channel_id,
+        "type": "messaging",
+        "kind": "twin_building_direct",
+        "name": channel_name,
+        "stream_channel_id": channel_id,
+        "source_edifici": _build_twin_admin_descriptor(source),
+        "target_edifici": _build_twin_admin_descriptor(target),
+        "members": [
+            {
+                "id": user.id,
+                "stream_user_id": source_stream_uid,
+                "email": user.email,
+                "name": _format_user_name(user),
+            },
+            {
+                "id": target_admin.id,
+                "stream_user_id": target_stream_uid,
+                "email": target_admin.email,
+                "name": _format_user_name(target_admin),
+            },
+        ],
+    }

--- a/backend/apps/chat/tests.py
+++ b/backend/apps/chat/tests.py
@@ -5,7 +5,8 @@ from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-
+from django.db.models.signals import post_save
+from apps.chat import signals as chat_signals
 from apps.accounts.models import Profile, RoleChoices, User
 from apps.buildings.models import Edifici, GrupComparable, Habitatge, Localitzacio
 
@@ -453,3 +454,182 @@ class ChannelPermissionTests(APITestCase):
         from apps.chat.services import validate_twin_channel_access
 
         self.assertFalse(validate_twin_channel_access(self.owner, 999999))
+
+# ---------------------------------------------------------------------------
+# US40 — Twin Building direct chat entre administradors de finca
+# ---------------------------------------------------------------------------
+
+@override_settings(STREAM_API_KEY="k", STREAM_API_SECRET="s", STREAM_TOKEN_EXPIRATION_SECONDS=3600)
+class TwinBuildingDirectChatTests(APITestCase):
+    def setUp(self):
+        # Evitem que els signals de xat facin crides reals a GetStream
+        # mentre preparem dades de test. Aquests tests validen els endpoints
+        # Twin Building, no la sincronització automàtica per signals.
+        post_save.disconnect(chat_signals.sync_profile_to_stream, sender=Profile)
+        post_save.disconnect(chat_signals.add_tenant_to_building_channel, sender=Habitatge)
+
+        self.addCleanup(
+            post_save.connect,
+            chat_signals.sync_profile_to_stream,
+            sender=Profile,
+        )
+        self.addCleanup(
+            post_save.connect,
+            chat_signals.add_tenant_to_building_channel,
+            sender=Habitatge,
+        )
+
+        self.grup = GrupComparable.objects.create(
+            idGrup=40,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="200-500",
+        )
+        self.altre_grup = GrupComparable.objects.create(
+            idGrup=41,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="500-1000",
+        )
+
+        self.admin_origen = User.objects.create_user(
+            email="admin.origen@example.com",
+            password="Pass123!",
+            first_name="Admin",
+            last_name="Origen",
+        )
+        _set_role(self.admin_origen, RoleChoices.ADMIN)
+
+        self.admin_desti = User.objects.create_user(
+            email="admin.desti@example.com",
+            password="Pass123!",
+            first_name="Admin",
+            last_name="Desti",
+        )
+        _set_role(self.admin_desti, RoleChoices.ADMIN)
+
+        self.admin_altre_grup = User.objects.create_user(
+            email="admin.altre@example.com",
+            password="Pass123!",
+        )
+        _set_role(self.admin_altre_grup, RoleChoices.ADMIN)
+
+        self.owner = User.objects.create_user(
+            email="owner.twin@example.com",
+            password="Pass123!",
+        )
+        _set_role(self.owner, RoleChoices.OWNER)
+
+        self.edifici_origen = _create_building(owner=self.admin_origen, grup=self.grup)
+        self.edifici_desti = _create_building(owner=self.admin_desti, grup=self.grup)
+        self.edifici_altre_grup = _create_building(owner=self.admin_altre_grup, grup=self.altre_grup)
+
+        Habitatge.objects.create(
+            referenciaCadastral="TWIN001",
+            planta="1",
+            porta="1A",
+            superficie=80.0,
+            edifici=self.edifici_origen,
+            usuari=self.owner,
+        )
+
+    def test_admin_can_list_twin_building_admins_same_group(self):
+        self.client.force_authenticate(user=self.admin_origen)
+
+        response = self.client.get(
+            reverse(
+                "chat-twin-building-admins",
+                kwargs={"edifici_id": self.edifici_origen.idEdifici},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+
+        result = response.data["results"][0]
+        self.assertEqual(result["edifici_id"], self.edifici_desti.idEdifici)
+        self.assertEqual(result["admin"]["email"], self.admin_desti.email)
+
+    def test_admin_list_does_not_include_own_building_or_other_group(self):
+        self.client.force_authenticate(user=self.admin_origen)
+
+        response = self.client.get(
+            reverse(
+                "chat-twin-building-admins",
+                kwargs={"edifici_id": self.edifici_origen.idEdifici},
+            )
+        )
+
+        ids = {item["edifici_id"] for item in response.data["results"]}
+
+        self.assertNotIn(self.edifici_origen.idEdifici, ids)
+        self.assertNotIn(self.edifici_altre_grup.idEdifici, ids)
+
+    def test_owner_cannot_list_twin_building_admins(self):
+        self.client.force_authenticate(user=self.owner)
+
+        response = self.client.get(
+            reverse(
+                "chat-twin-building-admins",
+                kwargs={"edifici_id": self.edifici_origen.idEdifici},
+            )
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch("apps.chat.services.get_stream_client")
+    def test_admin_can_create_direct_twin_building_channel(self, mock_get_client):
+        mock_client, mock_channel = _make_mock_stream_client()
+        mock_get_client.return_value = mock_client
+
+        self.client.force_authenticate(user=self.admin_origen)
+
+        response = self.client.post(
+            reverse(
+                "chat-twin-building-channel",
+                kwargs={"edifici_id": self.edifici_origen.idEdifici},
+            ),
+            {"target_edifici_id": self.edifici_desti.idEdifici},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["kind"], "twin_building_direct")
+        self.assertEqual(
+            response.data["id"],
+            f"twin_building_{self.edifici_origen.idEdifici}_{self.edifici_desti.idEdifici}_admins",
+        )
+
+        mock_client.channel.assert_called()
+        mock_channel.create.assert_called()
+        mock_channel.add_members.assert_called()
+
+    def test_cannot_create_channel_with_building_from_other_group(self):
+        self.client.force_authenticate(user=self.admin_origen)
+
+        response = self.client.post(
+            reverse(
+                "chat-twin-building-channel",
+                kwargs={"edifici_id": self.edifici_origen.idEdifici},
+            ),
+            {"target_edifici_id": self.edifici_altre_grup.idEdifici},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("mateix grup comparable", response.data["detail"])
+
+    def test_missing_target_edifici_id_returns_400(self):
+        self.client.force_authenticate(user=self.admin_origen)
+
+        response = self.client.post(
+            reverse(
+                "chat-twin-building-channel",
+                kwargs={"edifici_id": self.edifici_origen.idEdifici},
+            ),
+            {},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("target_edifici_id", response.data["detail"])

--- a/backend/apps/chat/urls.py
+++ b/backend/apps/chat/urls.py
@@ -1,9 +1,26 @@
 from django.urls import path
 
-from .views import ChatChannelsProvisionView, ChatChannelsView, ChatTokenView
+from .views import (
+    ChatChannelsProvisionView,
+    ChatChannelsView,
+    ChatTokenView,
+    TwinBuildingAdminsView,
+    TwinBuildingChannelView,
+)
 
 urlpatterns = [
     path("token/", ChatTokenView.as_view(), name="chat-token"),
     path("channels/", ChatChannelsView.as_view(), name="chat-channels"),
     path("channels/provision/", ChatChannelsProvisionView.as_view(), name="chat-channels-provision"),
+
+    path(
+        "twin-buildings/<int:edifici_id>/admins/",
+        TwinBuildingAdminsView.as_view(),
+        name="chat-twin-building-admins",
+    ),
+    path(
+        "twin-buildings/<int:edifici_id>/channels/",
+        TwinBuildingChannelView.as_view(),
+        name="chat-twin-building-channel",
+    ),
 ]

--- a/backend/apps/chat/views.py
+++ b/backend/apps/chat/views.py
@@ -12,7 +12,9 @@ from .services import (
     build_channel_descriptors,
     create_stream_token_for_user,
     get_or_create_channels_for_user,
+    get_or_create_twin_building_admin_channel,
     get_stream_user_id,
+    get_twin_building_admin_candidates,
 )
 
 logger = logging.getLogger(__name__)
@@ -96,3 +98,86 @@ class ChatChannelsProvisionView(APIView):
             )
 
         return Response({"count": len(channels), "results": channels})
+
+
+class TwinBuildingAdminsView(APIView):
+    """
+    GET: retorna administradors de finca d'edificis del mateix GrupComparable.
+
+    Només pot consultar-ho l'administrador de finca de l'edifici origen.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, edifici_id):
+        try:
+            admins = get_twin_building_admin_candidates(request.user, edifici_id)
+        except PermissionError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_403_FORBIDDEN)
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception:
+            logger.exception(
+                "Error consultant admins Twin Building per l'edifici %s i usuari %s.",
+                edifici_id,
+                request.user.id,
+            )
+            return Response(
+                {"detail": "Error consultant administradors d'edificis comparables."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        return Response({
+            "count": len(admins),
+            "results": admins,
+        })
+
+
+class TwinBuildingChannelView(APIView):
+    """
+    POST: crea o obté un canal directe entre dos administradors de finca
+    d'edificis del mateix GrupComparable.
+    """
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, edifici_id):
+        target_edifici_id = request.data.get("target_edifici_id")
+
+        if target_edifici_id is None:
+            return Response(
+                {"detail": "Cal informar 'target_edifici_id'."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            target_edifici_id = int(target_edifici_id)
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "'target_edifici_id' ha de ser un enter."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            channel = get_or_create_twin_building_admin_channel(
+                request.user,
+                edifici_id,
+                target_edifici_id,
+            )
+        except ImproperlyConfigured as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        except PermissionError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_403_FORBIDDEN)
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception:
+            logger.exception(
+                "Error creant canal Twin Building entre edifici %s i edifici %s per usuari %s.",
+                edifici_id,
+                target_edifici_id,
+                request.user.id,
+            )
+            return Response(
+                {"detail": "Error de connexió amb el servei de xat."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        return Response(channel, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Resum

Aquesta PR implementa el backend de la US40, reinterpretada com a xat Twin Building entre administradors de finca d’edificis comparables.

## Canvis principals

- Afegeix un endpoint per llistar administradors de finca d’edificis del mateix GrupComparable.
- Afegeix un endpoint per crear o obtenir un canal GetStream directe entre dos administradors de finca.
- Només l’administrador de finca de l’edifici origen pot consultar i crear canals Twin Building.
- Es valida que l’edifici destí pertanyi al mateix GrupComparable.
- S’evita crear xats amb el propi edifici o amb edificis gestionats pel mateix usuari.
- Es mantenen els endpoints existents de xat sense trencar compatibilitat.
- S’afegeixen tests per permisos, llistat de candidats i creació de canal.
- S’eviten crides externes reals a GetStream durant els tests.

## Endpoints nous

- `GET /api/chat/twin-buildings/{edifici_id}/admins/`
- `POST /api/chat/twin-buildings/{edifici_id}/channels/`

## Validació local

- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test apps.chat -v 2`
- `python manage.py test apps.accounts apps.buildings apps.leagues apps.seasons apps.participations apps.verification apps.chat -v 2`