### PR TITLE
Amplia el detall de verificacions per al panell admin

### DIFF
--- a/backend/apps/verification/serializers.py
+++ b/backend/apps/verification/serializers.py
@@ -1,5 +1,7 @@
 # apps/verification/serializers.py
 from rest_framework import serializers
+from django.contrib.auth import get_user_model
+from apps.buildings.models import Edifici
 
 from .models import (
     AdminFincaDocumentVerification,
@@ -7,6 +9,7 @@ from .models import (
     AdminFincaVerificationResult,
 )
 
+User = get_user_model()
 
 # ---------------------------------------------------------------------------
 # Sub-serializer per a cada document en el moment de la creació
@@ -97,6 +100,63 @@ class AdminFincaVerificationResultSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = fields
 
+class VerificationUserDetailSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = [
+            'id',
+            'first_name',
+            'last_name',
+            'email',
+        ]
+        read_only_fields = fields
+
+
+class VerificationEdificiDetailSerializer(serializers.ModelSerializer):
+    localitzacio = serializers.SerializerMethodField()
+    adreca = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Edifici
+        fields = [
+            'idEdifici',
+            'localitzacio',
+            'adreca',
+        ]
+        read_only_fields = fields
+
+    def get_localitzacio(self, obj):
+        loc = getattr(obj, 'localitzacio', None)
+
+        if loc is None:
+            return None
+
+        return {
+            'carrer': loc.carrer,
+            'numero': loc.numero,
+            'codiPostal': loc.codiPostal,
+            'barri': loc.barri,
+        }
+
+    def get_adreca(self, obj):
+        loc = getattr(obj, 'localitzacio', None)
+
+        if loc is None:
+            return f"Edifici {obj.idEdifici}"
+
+        carrer = loc.carrer or ''
+        numero = loc.numero
+        codi_postal = loc.codiPostal or ''
+
+        base = carrer.strip()
+
+        if numero is not None:
+            base = f"{base}, {numero}".strip(', ')
+
+        if codi_postal:
+            return f"{base} ({codi_postal})".strip()
+
+        return base or f"Edifici {obj.idEdifici}"
 
 class AdminFincaDocumentVerificationSerializer(serializers.ModelSerializer):
     """Serialitzador de lectura complet: inclou documents i resultat."""
@@ -104,12 +164,17 @@ class AdminFincaDocumentVerificationSerializer(serializers.ModelSerializer):
     documents = AdminFincaVerificationDocumentSerializer(many=True, read_only=True)
     result = AdminFincaVerificationResultSerializer(read_only=True)
 
+    user_detail = VerificationUserDetailSerializer(source='user', read_only=True)
+    edifici_detail = VerificationEdificiDetailSerializer(source='edifici', read_only=True)
+
     class Meta:
         model = AdminFincaDocumentVerification
         fields = [
             'id',
             'user',
+            'user_detail',
             'edifici',
+            'edifici_detail',
             'status',
             'celery_task_id',
             'documents',

--- a/backend/apps/verification/views.py
+++ b/backend/apps/verification/views.py
@@ -49,10 +49,15 @@ class AdminFincaDocumentVerificationListView(generics.ListAPIView):
 
     def get_queryset(self):
         qs = AdminFincaDocumentVerification.objects.select_related(
-            'result'
+            'user',
+            'edifici',
+            'edifici__localitzacio',
+            'result',
         ).prefetch_related('documents')
+
         if IsAdminSistema().has_permission(self.request, self):
             return qs
+
         return qs.filter(user=self.request.user)
 
 
@@ -66,10 +71,15 @@ class AdminFincaDocumentVerificationDetailView(generics.RetrieveAPIView):
 
     def get_queryset(self):
         qs = AdminFincaDocumentVerification.objects.select_related(
-            'result'
+            'user',
+            'edifici',
+            'edifici__localitzacio',
+            'result',
         ).prefetch_related('documents')
+
         if IsAdminSistema().has_permission(self.request, self):
             return qs
+
         return qs.filter(user=self.request.user)
 
 
@@ -99,7 +109,10 @@ class VerificacioRevisioView(APIView):
         # Carrega la verificació
         try:
             verification = AdminFincaDocumentVerification.objects.select_related(
-                'user', 'user__profile', 'edifici'
+                'user',
+                'user__profile',
+                'edifici',
+                'edifici__localitzacio',
             ).prefetch_related('documents').get(pk=pk)
         except AdminFincaDocumentVerification.DoesNotExist:
             return Response(


### PR DESCRIPTION
## Resum

Aquesta PR amplia el payload de `GET /api/verification/` per facilitar la visualització de verificacions documentals al panell d’administració.

Fins ara el frontend només rebia els IDs de `user` i `edifici`, cosa que obligava la UI a mostrar informació poc clara com “Usuari · Correu no disponible” o “Edifici 20”. Amb aquest canvi es mantenen aquests IDs per compatibilitat, però s’afegeixen camps de detall read-only per poder mostrar millor la card de revisió.

## Canvis principals

- Manté `user` i `edifici` com a IDs per compatibilitat amb el contracte actual.
- Afegeix `user_detail` amb:
  - `id`
  - `first_name`
  - `last_name`
  - `email`
- Afegeix `edifici_detail` amb:
  - `idEdifici`
  - `localitzacio`
  - `adreca` formatada
- Optimitza el queryset amb `select_related` per carregar usuari, edifici i localització sense queries innecessàries.
- Manté `documents`, `score`, `score_flags`, `suggeriment` i la resta de camps existents.
- No afegeix migracions perquè només és un canvi de serializer/API.

## Exemple de resposta

```json
{
  "id": 2,
  "user": 4,
  "user_detail": {
    "id": 4,
    "first_name": "Bernat",
    "last_name": "Vancells",
    "email": "bernat@example.com"
  },
  "edifici": 20,
  "edifici_detail": {
    "idEdifici": 20,
    "localitzacio": {
      "carrer": "Travessera de les Corts",
      "numero": 54,
      "codiPostal": "08028",
      "barri": "Les Corts"
    },
    "adreca": "Travessera de les Corts, 54 (08028)"
  },
  "status": "review",
  "documents": [],
  "score": 0.82,
  "score_flags": [],
  "suggeriment": "..."
}