### PR TITLE
fix: permet host de lemulador android

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -54,7 +54,7 @@ ENABLE_DEBUG_TOOLBAR = os.getenv("ENABLE_DEBUG_TOOLBAR", "False").lower() == "tr
 
 ALLOWED_HOSTS = env_list(
     "ALLOWED_HOSTS",
-    default="localhost,127.0.0.1,0.0.0.0",
+    default="localhost,127.0.0.1,0.0.0.0,10.0.2.2",
 )
 
 


### PR DESCRIPTION
## Resum

Aquest PR afegeix `10.0.2.2` al valor per defecte d’`ALLOWED_HOSTS`.

Això és necessari perquè el frontend Flutter, quan s’executa en Android Emulator, pugui connectar amb el backend Docker local a través de:

```text
http://10.0.2.2
```

## Validació

S’ha comprovat que el backend accepta el host de l’emulador:
```bash
curl -i -H "Host: 10.0.2.2" http://localhost/api/buildings/edificis/mapa/?limit=5

HTTP/1.1 401 Unauthorized
{"detail":"Authentication credentials were not provided."}
```
El 401 és esperat perquè l’endpoint requereix autenticació.

També s’ha executat:
```bash
python manage.py check
python manage.py makemigrations --check --dry-run
```