### PR TITLE
Add progress ranking window endpoints

### DIFF
--- a/backend/apps/leagues/tests.py
+++ b/backend/apps/leagues/tests.py
@@ -1,0 +1,105 @@
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+
+from apps.buildings.models import Edifici, GrupComparable, Localitzacio
+from apps.leagues.models import RankingHistorico
+from apps.seasons.models import Temporada
+
+
+User = get_user_model()
+
+
+def make_user(email="leagues@example.com"):
+    return User.objects.create_user(
+        email=email,
+        password="Password123",
+        first_name="User",
+    )
+
+
+@override_settings(REST_FRAMEWORK={
+    "DEFAULT_AUTHENTICATION_CLASSES": (),
+    "DEFAULT_PERMISSION_CLASSES": (),
+    "DEFAULT_THROTTLE_CLASSES": (),
+})
+class EvolucioRankingHistoricoAPITest(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.client.force_authenticate(user=make_user())
+
+        self.group = GrupComparable.objects.create(
+            idGrup=50,
+            zonaClimatica="A",
+            tipologia="Residencial",
+            rangSuperficie="0-100",
+        )
+        self.localitzacio = Localitzacio.objects.create(
+            carrer="Carrer Test",
+            numero=1,
+            codiPostal="08001",
+            barri="Centre",
+        )
+        self.edifici = Edifici.objects.create(
+            anyConstruccio=2000,
+            tipologia="Residencial",
+            superficieTotal=100,
+            nombrePlantes=1,
+            reglament="CTE",
+            orientacioPrincipal="Nord",
+            grupComparable=self.group,
+            localitzacio=self.localitzacio,
+        )
+
+        self.temporades = [
+            Temporada.objects.create(
+                nom=f"Temporada {year}",
+                dataInici=f"{year}-01-01",
+                dataFi=f"{year}-12-31",
+            )
+            for year in [2023, 2024, 2025]
+        ]
+
+        for index, temporada in enumerate(self.temporades, start=1):
+            RankingHistorico.objects.create(
+                edifici=self.edifici,
+                temporada=temporada,
+                categoria="PROGRES",
+                puntuacio=index * 10,
+                posicio=index,
+                divisio="Bronze",
+            )
+
+    def test_evolucio_sense_limit_mante_historial_complet(self):
+        response = self.client.get(
+            "/api/leagues/evolucio/"
+            f"?edifici={self.edifici.idEdifici}&categoria=PROGRES"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            [item["nom_temporada"] for item in response.data],
+            ["Temporada 2023", "Temporada 2024", "Temporada 2025"],
+        )
+
+    def test_evolucio_limit_retorna_ultimes_temporades_en_ordre_cronologic(self):
+        response = self.client.get(
+            "/api/leagues/evolucio/"
+            f"?edifici={self.edifici.idEdifici}&categoria=PROGRES&limit=2"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            [item["nom_temporada"] for item in response.data],
+            ["Temporada 2024", "Temporada 2025"],
+        )
+
+    def test_evolucio_limit_invalid_retorna_400(self):
+        response = self.client.get(
+            "/api/leagues/evolucio/"
+            f"?edifici={self.edifici.idEdifici}&categoria=PROGRES&limit=abc"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "limit must be a positive integer")

--- a/backend/apps/leagues/views.py
+++ b/backend/apps/leagues/views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets
+from rest_framework import viewsets, status
 from rest_framework.decorators import action, permission_classes
 from rest_framework.response import Response
 from .pagination import RankingPagination
@@ -110,17 +110,36 @@ class LligaViewSet(viewsets.ModelViewSet):
     def evolucio(self, request):
         edifici_id = request.query_params.get("edifici")
         categoria = request.query_params.get("categoria")
+        limit = request.query_params.get("limit")
 
         if not edifici_id or not categoria:
             return Response(
                 {"error": "edifici and categoria are required"},
-                status=400
+                status=status.HTTP_400_BAD_REQUEST
             )
 
         historial = RankingHistorico.objects.filter(
             edifici_id=edifici_id,
             categoria=categoria.upper()
         ).select_related("temporada").order_by("temporada__dataInici")
+
+        if limit is not None:
+            try:
+                limit = int(limit)
+            except (TypeError, ValueError):
+                return Response(
+                    {"error": "limit must be a positive integer"},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+            if limit <= 0:
+                return Response(
+                    {"error": "limit must be a positive integer"},
+                    status=status.HTTP_400_BAD_REQUEST
+                )
+
+            historial = list(historial.order_by("-temporada__dataInici")[:limit])
+            historial.reverse()
 
         data = [
             {

--- a/backend/apps/seasons/tests.py
+++ b/backend/apps/seasons/tests.py
@@ -1,6 +1,6 @@
 from datetime import date
 
-from django.test import TestCase, RequestFactory
+from django.test import TestCase, RequestFactory, override_settings
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.admin.sites import AdminSite
 from rest_framework import status
@@ -9,7 +9,7 @@ from django.contrib.auth import get_user_model
 
 from .models import Temporada, EstatTemporada
 from .admin import TemporadaAdmin
-from apps.leagues.models import Lliga
+from apps.leagues.models import Lliga, RankingHistorico
 from apps.participations.models import Participacio
 from apps.buildings.models import Edifici, GrupComparable, Localitzacio
 
@@ -802,3 +802,122 @@ class TemporadaRankingAPITest(APITestCase):
         posicions = [r["posicio"] for r in results]
 
         self.assertEqual(posicions, [1, 2, 3])
+
+
+@override_settings(REST_FRAMEWORK={
+    "DEFAULT_AUTHENTICATION_CLASSES": (),
+    "DEFAULT_PERMISSION_CLASSES": (),
+    "DEFAULT_THROTTLE_CLASSES": (),
+})
+class TemporadaRankingProgresAPITest(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = make_user(email="ranking-progres@example.com")
+        self.client.force_authenticate(user=self.user)
+
+        self.group = GrupComparable.objects.create(
+            idGrup=10,
+            zonaClimatica='A',
+            tipologia='Residencial',
+            rangSuperficie='0-100'
+        )
+
+        self.temporada_2023 = Temporada.objects.create(
+            nom='2023',
+            dataInici='2023-01-01',
+            dataFi='2023-12-31',
+        )
+        self.temporada_2024 = Temporada.objects.create(
+            nom='2024',
+            dataInici='2024-01-01',
+            dataFi='2024-12-31',
+        )
+        self.temporada_2025 = Temporada.objects.create(
+            nom='2025',
+            dataInici='2025-01-01',
+            dataFi='2025-12-31',
+        )
+
+        self.edificis = []
+        for index, carrer in enumerate(['Aragó', 'Diagonal', 'Gran Via'], start=1):
+            localitzacio = Localitzacio.objects.create(
+                carrer=carrer,
+                numero=index,
+                codiPostal=f'0800{index}',
+                barri='Centre'
+            )
+            self.edificis.append(Edifici.objects.create(
+                anyConstruccio=2000 + index,
+                tipologia='Residencial',
+                superficieTotal=100 + index,
+                nombrePlantes=1,
+                reglament='CTE',
+                orientacioPrincipal='Nord',
+                grupComparable=self.group,
+                localitzacio=localitzacio
+            ))
+
+        self._snapshot(self.edificis[0], self.temporada_2023, 40, 3, 'Bronze')
+        self._snapshot(self.edificis[0], self.temporada_2024, 50, 2, 'Silver')
+        self._snapshot(self.edificis[0], self.temporada_2025, 80, 1, 'Gold')
+
+        self._snapshot(self.edificis[1], self.temporada_2023, 20, 2, 'Bronze')
+        self._snapshot(self.edificis[1], self.temporada_2024, 65, 1, 'Silver')
+        self._snapshot(self.edificis[1], self.temporada_2025, 75, 2, 'Silver')
+
+        self._snapshot(self.edificis[2], self.temporada_2023, 35, 1, 'Bronze')
+        self._snapshot(self.edificis[2], self.temporada_2024, 45, 3, 'Bronze')
+        self._snapshot(self.edificis[2], self.temporada_2025, 75, 3, 'Silver')
+
+    def _snapshot(self, edifici, temporada, puntuacio, posicio, divisio):
+        return RankingHistorico.objects.create(
+            edifici=edifici,
+            temporada=temporada,
+            categoria='PROGRES',
+            puntuacio=puntuacio,
+            posicio=posicio,
+            divisio=divisio,
+        )
+
+    def test_ranking_progres_ordena_per_delta_i_desempata_establement(self):
+        response = self.client.get(
+            f'/api/seasons/{self.temporada_2025.pk}/ranking/progres/?window=3'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(
+            [item['edifici'] for item in response.data],
+            [
+                self.edificis[1].idEdifici,
+                self.edificis[0].idEdifici,
+                self.edificis[2].idEdifici,
+            ]
+        )
+        self.assertEqual([item['delta'] for item in response.data], [55, 40, 40])
+        self.assertEqual([item['posicio'] for item in response.data], [1, 2, 3])
+        self.assertEqual(response.data[0]['puntuacio_inicial'], 20)
+        self.assertEqual(response.data[0]['puntuacio_actual'], 75)
+        self.assertEqual(response.data[0]['divisio_actual'], 'Silver')
+        self.assertEqual(len(response.data[0]['serie_temporal']), 3)
+
+    def test_ranking_progres_window_limita_finestra_de_temporades(self):
+        response = self.client.get(
+            f'/api/seasons/{self.temporada_2025.pk}/ranking/progres/?window=2'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0]['edifici'], self.edificis[0].idEdifici)
+        self.assertEqual(response.data[0]['delta'], 30)
+        self.assertEqual(
+            [item['nom_temporada'] for item in response.data[0]['serie_temporal']],
+            ['2024', '2025']
+        )
+
+    def test_ranking_progres_window_invalid_retorna_400(self):
+        response = self.client.get(
+            f'/api/seasons/{self.temporada_2025.pk}/ranking/progres/?window=0'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['error'], 'window must be a positive integer')

--- a/backend/apps/seasons/views.py
+++ b/backend/apps/seasons/views.py
@@ -16,7 +16,7 @@ from .serializers import TemporadaSerializer
 from .services import actualitzar_puntuacions_base_inici_temporada
 from apps.participations.models import Participacio
 from apps.participations.serializers import RankingSerializer
-from apps.leagues.models import Lliga
+from apps.leagues.models import Lliga, RankingHistorico
 from apps.buildings.models import GrupComparable
 from apps.leagues.pagination import RankingPagination
 
@@ -27,7 +27,7 @@ class TemporadaViewSet(viewsets.ModelViewSet):
     permission_classes=[IsAuthenticated]
 
     def get_permissions(self):
-        if self.action in ['list', 'retrieve', 'ranking', 'posicio_edifici']:
+        if self.action in ['list', 'retrieve', 'ranking', 'ranking_progres', 'posicio_edifici']:
             return [IsAuthenticated()]
         return [IsAdminSistema()]
 
@@ -112,6 +112,101 @@ class TemporadaViewSet(viewsets.ModelViewSet):
             item["posicio"] = participacio.posicio_calculada
 
         return paginator.get_paginated_response(data)
+
+    @action(detail=True, methods=["get"], url_path="ranking/progres")
+    def ranking_progres(self, request, pk=None):
+        temporada = self.get_object()
+        window = request.query_params.get("window", 5)
+
+        try:
+            window = int(window)
+        except (TypeError, ValueError):
+            return Response(
+                {"error": "window must be a positive integer"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        if window <= 0:
+            return Response(
+                {"error": "window must be a positive integer"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        temporades = list(
+            Temporada.objects
+            .filter(dataInici__lte=temporada.dataInici)
+            .order_by("-dataInici")[:window]
+        )
+        temporades.reverse()
+        temporada_ids = [t.id_temporada for t in temporades]
+
+        snapshots_actuals = list(
+            RankingHistorico.objects
+            .select_related("edifici", "edifici__localitzacio", "temporada")
+            .filter(temporada=temporada, categoria="PROGRES")
+        )
+        edifici_ids = [snapshot.edifici_id for snapshot in snapshots_actuals]
+
+        historial = (
+            RankingHistorico.objects
+            .select_related("edifici", "edifici__localitzacio", "temporada")
+            .filter(
+                edifici_id__in=edifici_ids,
+                temporada_id__in=temporada_ids,
+                categoria="PROGRES",
+            )
+            .order_by("edifici_id", "temporada__dataInici")
+        )
+
+        series_per_edifici = {}
+        for snapshot in historial:
+            series_per_edifici.setdefault(snapshot.edifici_id, []).append(snapshot)
+
+        ranking = []
+        for snapshot_actual in snapshots_actuals:
+            serie = series_per_edifici.get(snapshot_actual.edifici_id, [])
+            if not serie:
+                continue
+
+            snapshot_inicial = serie[0]
+            puntuacio_actual = snapshot_actual.puntuacio
+            puntuacio_inicial = snapshot_inicial.puntuacio
+            delta = puntuacio_actual - puntuacio_inicial
+            edifici = snapshot_actual.edifici
+            localitzacio = edifici.localitzacio
+
+            ranking.append({
+                "edifici": edifici.idEdifici,
+                "nom": str(edifici),
+                "adreca": str(localitzacio) if localitzacio else None,
+                "puntuacio_inicial": puntuacio_inicial,
+                "puntuacio_actual": puntuacio_actual,
+                "delta": delta,
+                "divisio_actual": snapshot_actual.divisio,
+                "serie_temporal": [
+                    {
+                        "temporada": item.temporada.id_temporada,
+                        "nom_temporada": item.temporada.nom,
+                        "puntuacio": item.puntuacio,
+                        "posicio": item.posicio,
+                        "divisio": item.divisio,
+                    }
+                    for item in serie
+                ],
+            })
+
+        ranking.sort(
+            key=lambda item: (
+                -item["delta"],
+                -item["puntuacio_actual"],
+                item["edifici"],
+            )
+        )
+
+        for posicio, item in enumerate(ranking, start=1):
+            item["posicio"] = posicio
+
+        return Response(ranking)
 
     @action(detail=True, methods=["get"])
     def posicio_edifici(self, request, pk=None):


### PR DESCRIPTION
## Resum
- Afegeix el paràmetre opcional `limit` a `GET /api/leagues/evolucio/`, mantenint l'ordre cronològic ascendent a la resposta.
- Afegeix `GET /api/seasons/{seasonId}/ranking/progres/?window=N` per retornar edificis ordenats per progrés acumulat.
- Calcula `delta = puntuacio_actual - puntuacio_inicial` i ordena per `delta` descendent, `puntuacio_actual` descendent i `edifici` ascendent.
- Inclou `serie_temporal` curta dins la finestra demanada.
- Afegeix tests focalitzats per `limit`, `window`, ordre i validació d'errors.

## Validació
- `.venv/bin/python manage.py check` OK
- `.venv/bin/python -m py_compile apps/leagues/views.py apps/seasons/views.py apps/leagues/tests.py apps/seasons/tests.py` OK
- `git diff --check` OK
- Tests focalitzats executats amb settings SQLite temporals del procés: 6 tests OK
- Tests amb PostgreSQL local no executables: Django falla creant la DB de test amb `django.db.utils.OperationalError: connection is bad: no error details available`.
- Suite completa amb SQLite temporal: 567 tests executats, però falla per issues preexistents d'entorn/throttling/concurrència, principalment respostes 429 i alguns 500 en tests de concurrència.

Closes #130