### PR TITLE
fix: bloqueja accés a edificis amb verificació documental pendent

### DIFF
--- a/backend/apps/accounts/permissions.py
+++ b/backend/apps/accounts/permissions.py
@@ -91,12 +91,18 @@ class ABACMixin:
             return  # Accés total
 
         if role == RoleChoices.ADMIN:
-            te_acces = user.edificis_administrats.filter(idEdifici=edifici_id).exists()
+            from apps.buildings.models import Edifici
+            from apps.verification.access import effective_admin_buildings_queryset
+
+            te_acces = effective_admin_buildings_queryset(
+                Edifici.objects.filter(idEdifici=edifici_id),
+                user,
+            ).exists()
             if not te_acces:
                 _deny(
                     request,
                     accio,
-                    "L'edifici no pertany a la cartera de gestió de l'administrador."
+                    "L'edifici no pertany a la cartera de gestió aprovada de l'administrador."
                 )
         else:
             te_acces = user.habitatges_on_resideix.filter(edifici__idEdifici=edifici_id).exists()

--- a/backend/apps/accounts/tests.py
+++ b/backend/apps/accounts/tests.py
@@ -1598,3 +1598,103 @@ class GoogleOAuthTests(APITestCase):
                 email="invalid-role-google@example.com"
             ).exists()
         )
+
+
+class PendingAdminVerificationAccessTests(BaseTestData):
+    """Regressió: un admin finca no pot accedir a edificis amb verificació pendent."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin_finca = cls._create_user("pending-admin@example.com", RoleChoices.ADMIN)
+        cls.owner = cls._create_user("owner-pending@example.com", RoleChoices.OWNER)
+
+        cls.grup = GrupComparable.objects.create(
+            idGrup=909,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="100-200",
+        )
+
+        cls.edifici_pending = cls._create_edifici(
+            administrador=cls.admin_finca,
+            grup=cls.grup,
+            carrer="Carrer Pending",
+            numero=91,
+        )
+        cls.edifici_approved = cls._create_edifici(
+            administrador=cls.admin_finca,
+            grup=cls.grup,
+            carrer="Carrer Approved",
+            numero=92,
+        )
+        cls.edifici_legacy = cls._create_edifici(
+            administrador=cls.admin_finca,
+            grup=cls.grup,
+            carrer="Carrer Legacy",
+            numero=93,
+        )
+
+        Habitatge.objects.create(
+            referenciaCadastral="PENDING-OWNER-1",
+            planta="1",
+            porta="A",
+            superficie=80,
+            edifici=cls.edifici_pending,
+            usuari=cls.owner,
+            propietari=cls.owner,
+        )
+
+        from apps.verification.models import AdminFincaDocumentVerification
+
+        AdminFincaDocumentVerification.objects.create(
+            user=cls.admin_finca,
+            edifici=cls.edifici_pending,
+            status=AdminFincaDocumentVerification.Status.PENDING,
+        )
+        AdminFincaDocumentVerification.objects.create(
+            user=cls.admin_finca,
+            edifici=cls.edifici_approved,
+            status=AdminFincaDocumentVerification.Status.APPROVED,
+        )
+
+    def test_me_edificis_no_retorna_edifici_amb_verificacio_pending(self):
+        self.client.force_authenticate(user=self.admin_finca)
+
+        response = self.client.get(reverse("me-edificis"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {item["idEdifici"] for item in response.data}
+
+        self.assertNotIn(self.edifici_pending.idEdifici, returned_ids)
+        self.assertIn(self.edifici_approved.idEdifici, returned_ids)
+        self.assertIn(self.edifici_legacy.idEdifici, returned_ids)
+
+    def test_admin_finca_pending_no_pot_accedir_detail_edifici(self):
+        self.client.force_authenticate(user=self.admin_finca)
+
+        response = self.client.get(
+            reverse("edifici-detail", args=[self.edifici_pending.idEdifici])
+        )
+
+        self.assertIn(
+            response.status_code,
+            [status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND],
+        )
+
+    def test_admin_finca_approved_pot_accedir_detail_edifici(self):
+        self.client.force_authenticate(user=self.admin_finca)
+
+        response = self.client.get(
+            reverse("edifici-detail", args=[self.edifici_approved.idEdifici])
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_owner_vinculat_no_es_bloqueja_per_verificacio_admin_pending(self):
+        self.client.force_authenticate(user=self.owner)
+
+        response = self.client.get(
+            reverse("edifici-detail", args=[self.edifici_pending.idEdifici])
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -184,8 +184,14 @@ class MeEdificisView(APIView):
         if user.is_superuser:
             edificis = Edifici.objects.select_related("localitzacio").all()
         elif role == RoleChoices.ADMIN:
-            # Admin de finca: edificis de la seva cartera
-            edificis = user.edificis_administrats.select_related("localitzacio").all()
+            # Admin de finca: només edificis amb assignació efectiva.
+            # Si hi ha verificació documental per aquest edifici, ha d'estar approved.
+            from apps.verification.access import effective_admin_buildings_queryset
+
+            edificis = effective_admin_buildings_queryset(
+                Edifici.objects.select_related("localitzacio"),
+                user,
+            )
         else:
             # Owner / Tenant: edificis on té vinculació per habitatge
             edificis = (

--- a/backend/apps/buildings/permissions.py
+++ b/backend/apps/buildings/permissions.py
@@ -41,7 +41,7 @@ class EsAdminEdifici(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         # ABAC
-        if obj.administradorFinca != request.user:
+        if not _es_admin_finca_efectiu(request.user, obj):
             log_denial(request, view.action, 'No és admin d\'aquest edifici', obj.idEdifici)
             return False
         return True
@@ -69,7 +69,7 @@ class EsAdminOPropietariEdifici(BasePermission):
         role = user.profile.role
 
         # ABAC + RBAC combinats
-        if role == RoleChoices.ADMIN and obj.administradorFinca == user:
+        if role == RoleChoices.ADMIN and _es_admin_finca_efectiu(user, obj):
             return True
         te_vinculacio_edifici = (
             obj.habitatges.filter(usuari=user).exists()
@@ -110,7 +110,7 @@ class EsAdminOPropietariHabitatge(BasePermission):
         user = request.user
         role = user.profile.role
 
-        if role == RoleChoices.ADMIN and obj.edifici.administradorFinca == user:
+        if role == RoleChoices.ADMIN and _es_admin_finca_efectiu(user, obj.edifici):
             return True
         if role in (RoleChoices.OWNER, RoleChoices.TENANT) and obj.te_vinculacio(user):
             return True
@@ -140,7 +140,7 @@ class EsOwnerOAdminHabitatge(BasePermission):
         user = request.user
         role = user.profile.role
 
-        if role == RoleChoices.ADMIN and obj.edifici.administradorFinca == user:
+        if role == RoleChoices.ADMIN and _es_admin_finca_efectiu(user, obj.edifici):
             return True
         if role == RoleChoices.OWNER and obj.es_propietari(user):
             return True
@@ -208,6 +208,12 @@ class EsAdminMilloraImplementada(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return self.has_permission(request, view)
+
+
+
+def _es_admin_finca_efectiu(user, edifici):
+    from apps.verification.access import admin_assignment_is_effective
+    return admin_assignment_is_effective(user, edifici)
 
 
 class HasAPIKey(BasePermission):

--- a/backend/apps/buildings/serializers.py
+++ b/backend/apps/buildings/serializers.py
@@ -570,9 +570,14 @@ class EdificiDetailSerializer(serializers.ModelSerializer):
 
         if user.is_superuser:
             qs = obj.habitatges.all()
-        elif role == RoleChoices.ADMIN and obj.administradorFinca == user:
-            # Administrador de finca: veu tots els habitatges de l'edifici que administra.
-            qs = obj.habitatges.all()
+        elif role == RoleChoices.ADMIN:
+            from apps.verification.access import admin_assignment_is_effective
+
+            if admin_assignment_is_effective(user, obj):
+                # Administrador de finca efectiu: veu tots els habitatges de l'edifici que administra.
+                qs = obj.habitatges.all()
+            else:
+                qs = obj.habitatges.none()
         else:
             # Owner/Tenant: només veu els habitatges vinculats al seu usuari.
             qs = obj.habitatges.filter(Q(usuari=user) | Q(propietari=user) | Q(llogater=user))

--- a/backend/apps/buildings/tests.py
+++ b/backend/apps/buildings/tests.py
@@ -2989,10 +2989,14 @@ class TestAdminFincaAltaEdifici(BaseTestData):
         # Comprovem que es crea correctament (201 Created)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(Edifici.objects.count(), edificis_abans + 1)
-        
-        # Comprovem que l'edifici nou s'ha assignat a aquest admin
+
+        # La creació ja no concedeix gestió immediata.
+        # L'assignació efectiva queda pendent d'una verificació documental approved.
         nou_edifici = Edifici.objects.latest('idEdifici')
-        self.assertEqual(nou_edifici.administradorFinca, admin)
+        self.assertIsNone(nou_edifici.administradorFinca)
+        self.assertEqual(response.data["edifici_id"], nou_edifici.idEdifici)
+        self.assertTrue(response.data["requereix_verificacio"])
+        self.assertIn("documental", response.data["message"].lower())
 
 class TestRestriccionsHabitatge(BaseTestData):
     """

--- a/backend/apps/buildings/views.py
+++ b/backend/apps/buildings/views.py
@@ -160,7 +160,8 @@ class EdificiViewSet(viewsets.ModelViewSet):
         role = user.profile.role
         qs = Edifici.actius.all()
         if role == RoleChoices.ADMIN:
-            return qs.filter(administradorFinca=user)
+            from apps.verification.access import effective_admin_buildings_queryset
+            return effective_admin_buildings_queryset(qs, user)
         if role == RoleChoices.OWNER:
             return qs.filter(
                 Q(habitatges__usuari=user) |
@@ -182,11 +183,16 @@ class EdificiViewSet(viewsets.ModelViewSet):
     
     def perform_create(self, serializer):
         """
-        Quan un administrador de finca crea un edifici, el backend el vincula
-        automàticament a l'usuari autenticat. El frontend no ha d'enviar
-        administradorFinca manualment.
+        Crear un edifici no concedeix gestió immediata a l'admin finca.
+
+        La vinculació efectiva s'ha de produir quan la verificació documental
+        passa a approved. Això evita que un usuari pugui accedir a l'edifici
+        mentre la documentació encara està pending/running/review.
         """
-        serializer.save(administradorFinca=self.request.user)
+        if self.request.user.is_superuser:
+            serializer.save()
+        else:
+            serializer.save(administradorFinca=None)
 
     def get_permissions(self):
         if self.action in ['destroy']:
@@ -430,18 +436,22 @@ class EdificiViewSet(viewsets.ModelViewSet):
         return items
 
     def _es_admin_de_finca_edifici(self, request, edifici):
-        return (
+        if not (
             request.user.is_authenticated
             and hasattr(request.user, 'profile')
             and request.user.profile.role == RoleChoices.ADMIN
-            and edifici.administradorFinca_id == request.user.id
-        )
+        ):
+            return False
+
+        from apps.verification.access import admin_assignment_is_effective
+        return admin_assignment_is_effective(request.user, edifici)
 
     def _pot_votar_votacio(self, user, edifici):
         if not user.is_authenticated or not hasattr(user, 'profile'):
             return False
 
-        if edifici.administradorFinca_id == user.id:
+        from apps.verification.access import admin_assignment_is_effective
+        if admin_assignment_is_effective(user, edifici):
             return True
 
         if user.profile.role != RoleChoices.OWNER:
@@ -1010,7 +1020,8 @@ class EdificiViewSet(viewsets.ModelViewSet):
         user = request.user
 
         is_system_admin = bool(user.is_staff or user.is_superuser)
-        is_finca_admin = bool(edifici.administradorFinca_id == user.id)
+        from apps.verification.access import admin_assignment_is_effective
+        is_finca_admin = admin_assignment_is_effective(user, edifici)
 
         if not (is_system_admin or is_finca_admin):
             return Response(
@@ -1713,10 +1724,18 @@ class AdminFincaEdificiAltaView(APIView):
                     status=status.HTTP_409_CONFLICT
                 )
             
-            # Assignar si existeix però no té admin
-            edifici.administradorFinca = request.user
-            edifici.save()
-            return Response({"message": "Edifici assignat correctament."}, status=status.HTTP_200_OK)
+            # No assignem encara: cal verificació documental approved.
+            return Response(
+                {
+                    "message": (
+                        "Edifici localitzat. Per administrar-lo cal completar "
+                        "i aprovar la verificació documental."
+                    ),
+                    "edifici_id": edifici.idEdifici,
+                    "requereix_verificacio": True,
+                },
+                status=status.HTTP_200_OK,
+            )
         
         # Si l'edifici no existeix, el creem i l'assignem
         if not loc:
@@ -1734,10 +1753,17 @@ class AdminFincaEdificiAltaView(APIView):
             superficieTotal=data.get('superficieTotal'),
             reglament=data.get('reglament'),
             orientacioPrincipal=data.get('orientacioPrincipal'),
-            administradorFinca=request.user,
+            administradorFinca=None,
         )
 
         return Response(
-            {"message": "Edifici creat i assignat correctament.", "edifici_id": nouEdifici.idEdifici}, 
+            {
+                "message": (
+                    "Edifici creat. Per administrar-lo cal completar "
+                    "i aprovar la verificació documental."
+                ),
+                "edifici_id": nouEdifici.idEdifici,
+                "requereix_verificacio": True,
+            },
             status=status.HTTP_201_CREATED
         )

--- a/backend/apps/verification/access.py
+++ b/backend/apps/verification/access.py
@@ -1,0 +1,62 @@
+"""Helpers d'autorització relacionats amb verificació documental.
+
+Regla funcional:
+- si un admin finca té una verificació documental per un edifici, només pot
+  gestionar-lo quan existeix una verificació APPROVED;
+- mentre la verificació és pending/running/review/rejected, no té accés efectiu;
+- per compatibilitat amb assignacions manuals/històriques sense verificació,
+  una assignació directa sense cap verificació associada es considera vàlida.
+"""
+
+from django.db.models import Exists, OuterRef, Q
+
+from apps.verification.models import AdminFincaDocumentVerification
+
+
+def admin_assignment_is_effective(user, edifici) -> bool:
+    """Retorna True si l'usuari és admin efectiu de l'edifici."""
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+
+    if getattr(user, "is_superuser", False):
+        return True
+
+    if not edifici or edifici.administradorFinca_id != user.id:
+        return False
+
+    verifications = AdminFincaDocumentVerification.objects.filter(
+        user=user,
+        edifici=edifici,
+    )
+
+    if not verifications.exists():
+        return True
+
+    return verifications.filter(
+        status=AdminFincaDocumentVerification.Status.APPROVED,
+    ).exists()
+
+
+def effective_admin_buildings_queryset(queryset, user):
+    """Filtra edificis administrats visibles per un admin finca."""
+    user_verifications = AdminFincaDocumentVerification.objects.filter(
+        user=user,
+        edifici=OuterRef("pk"),
+    )
+    approved_verifications = user_verifications.filter(
+        status=AdminFincaDocumentVerification.Status.APPROVED,
+    )
+
+    return (
+        queryset
+        .filter(administradorFinca=user)
+        .annotate(
+            _te_verificacio_admin=Exists(user_verifications),
+            _te_verificacio_admin_aprovada=Exists(approved_verifications),
+        )
+        .filter(
+            Q(_te_verificacio_admin=False)
+            | Q(_te_verificacio_admin_aprovada=True)
+        )
+        .distinct()
+    )

--- a/backend/apps/verification/serializers.py
+++ b/backend/apps/verification/serializers.py
@@ -275,6 +275,7 @@ class AdminFincaDocumentVerificationCreateSerializer(serializers.ModelSerializer
         actives = [
             AdminFincaDocumentVerification.Status.PENDING,
             AdminFincaDocumentVerification.Status.RUNNING,
+            AdminFincaDocumentVerification.Status.REVIEW,
         ]
 
         if AdminFincaDocumentVerification.objects.filter(


### PR DESCRIPTION
````markdown
## Resum

Aquest PR corregeix el flux d’accés dels administradors de finca quan tenen una verificació documental pendent.

Fins ara, quan un usuari amb rol d’administrador de finca sol·licitava vincular-se a un edifici o creava un edifici, l’edifici podia quedar assignat o aparèixer al seu perfil abans que l’administrador de sistema aprovés la verificació documental.

Aquest comportament podia provocar que un usuari accedís al detall o a la gestió d’un edifici abans que la seva documentació hagués estat revisada i aprovada.

Amb aquest canvi, un edifici només es considera administrat de manera efectiva per un administrador de finca quan existeix una verificació documental en estat `approved`.

---

## Issue resolta

**Evitar accés a edificis amb verificació documental pendent**

Flux correcte esperat:

1. L’administrador de finca sol·licita vincular-se a un edifici existent o crea un edifici.
2. Es crea o queda pendent una verificació documental.
3. Mentre la verificació no estigui aprovada, l’usuari no ha de veure ni accedir a l’edifici com a administrador.
4. Quan l’administrador de sistema aprova la verificació:
   - s’assigna `edifici.administradorFinca = user`;
   - se sincronitza `profile.estatValidacioAdmin = aprovat`;
   - l’edifici apareix al perfil de l’administrador de finca;
   - els permisos de detall i gestió passen correctament.

---

## Canvis principals

### 1. Control centralitzat d’accés efectiu

S’ha afegit el fitxer:

```text
backend/apps/verification/access.py
````

Aquest fitxer centralitza la lògica d’autorització relacionada amb verificacions documentals.

Inclou dos helpers principals:

```python
admin_assignment_is_effective(user, edifici)
```

Determina si un usuari és administrador de finca efectiu d’un edifici.

```python
effective_admin_buildings_queryset(queryset, user)
```

Filtra els edificis que un administrador de finca pot veure com a administrats.

La regla aplicada és:

* si l’edifici té verificacions documentals associades a aquell usuari, només es considera accessible si alguna està en estat `approved`;
* si la verificació està en estat `pending`, `running`, `review` o `rejected`, l’usuari no té accés efectiu;
* si no existeix cap verificació associada, es manté compatibilitat amb assignacions antigues o assignacions manuals fetes pel sistema.

Aquesta compatibilitat és important per no trencar dades històriques, dades de demo o edificis assignats manualment per administradors de sistema.

---

### 2. `/api/accounts/me/edificis/`

S’ha modificat el llistat d’edificis del perfil.

Abans, per a un administrador de finca, l’endpoint retornava directament els edificis relacionats amb:

```python
user.edificis_administrats
```

Ara utilitza:

```python
effective_admin_buildings_queryset(...)
```

Això evita que un edifici aparegui al perfil de l’administrador de finca si la verificació documental encara no està aprovada.

Comportament actual:

* verificació `pending` / `running` / `review` / `rejected`:

  * l’edifici no apareix a `/api/accounts/me/edificis/`;
* verificació `approved`:

  * l’edifici sí que apareix com a edifici administrat;
* assignació antiga sense verificació:

  * es manté visible per compatibilitat.

---

### 3. Permisos de detall i gestió d’edifici

S’han reforçat els permisos perquè no sigui suficient comprovar només:

```python
edifici.administradorFinca == request.user
```

Ara els permisos passen per la comprovació d’assignació efectiva.

Això evita que un usuari pugui accedir directament a un edifici canviant l’ID a la URL si la seva verificació documental encara està pendent.

S’han actualitzat comprovacions en:

* permisos d’edifici;
* permisos d’habitatge;
* accés a dades energètiques;
* permisos de detall;
* permisos de gestió;
* accions que depenen del rol d’administrador de finca.

---

### 4. Queryset d’edificis

S’ha modificat el `get_queryset` d’edificis per al rol d’administrador de finca.

Abans:

```python
qs.filter(administradorFinca=user)
```

Ara:

```python
effective_admin_buildings_queryset(qs, user)
```

Això fa que el filtre d’accés sigui coherent tant en el perfil com en els endpoints d’edificis.

---

### 5. Creació i vinculació d’edificis

S’ha modificat el flux d’alta o vinculació d’edificis per administradors de finca.

Abans, quan un administrador de finca creava un edifici o es vinculava a un edifici existent sense administrador, el backend podia assignar directament:

```python
edifici.administradorFinca = request.user
```

Ara això ja no passa de forma immediata.

Nou comportament:

* crear un edifici no concedeix gestió immediata;
* vincular-se a un edifici existent no concedeix gestió immediata;
* la resposta indica que cal completar i aprovar la verificació documental;
* l’assignació efectiva queda pendent fins que l’administrador de sistema aprovi la verificació.

Exemple de resposta esperada:

```json
{
  "message": "Edifici creat. Per administrar-lo cal completar i aprovar la verificació documental.",
  "edifici_id": 123,
  "requereix_verificacio": true
}
```

Això evita que l’edifici aparegui com a administrat abans de completar el procés de revisió documental.

---

### 6. Verificacions actives

S’ha actualitzat la validació de verificacions duplicades.

Ara l’estat `review` també es considera una verificació activa, juntament amb:

```text
pending
running
review
```

Això evita que un usuari pugui crear una nova verificació duplicada mentre una verificació anterior encara està pendent de revisió.

---

### 7. Serialització d’habitatges dins el detall d’edifici

S’ha ajustat la lògica que determina quins habitatges pot veure un administrador de finca dins el detall d’un edifici.

Ara només pot veure tots els habitatges de l’edifici si és administrador de finca efectiu segons la verificació documental.

Si la verificació està pendent, no es concedeix aquest accés ampli.

Els propietaris i llogaters mantenen el comportament actual: només veuen els habitatges amb els quals tenen vinculació.

---

## Tests afegits

S’ha afegit una nova classe de tests de regressió:

```python
PendingAdminVerificationAccessTests
```

Aquests tests validen específicament el nou comportament.

### Casos coberts

#### 1. Un admin finca amb verificació pendent no veu l’edifici a `/me/edificis/`

Es valida que un edifici amb verificació `pending` no apareix al llistat d’edificis administrats.

#### 2. Un admin finca amb verificació pendent no pot accedir al detall de l’edifici

Es valida que el backend retorna `403` o `404` quan l’administrador de finca intenta accedir a un edifici amb verificació pendent.

#### 3. Un admin finca amb verificació aprovada sí que pot accedir al detall

Es valida que l’accés funciona correctament quan existeix una verificació `approved`.

#### 4. Un owner vinculat no queda bloquejat per la verificació pendent de l’admin finca

Es valida que el bloqueig només afecta l’accés com a administrador de finca.

Un propietari vinculat a un habitatge de l’edifici continua podent accedir al detall segons la seva relació amb l’habitatge.

---

## Tests actualitzats

S’ha actualitzat el test existent:

```python
TestAdminFincaAltaEdifici.test_crear_edifici_si_no_existeix
```

Aquest test encara assumia el comportament antic: que crear un edifici com a administrador de finca assignava immediatament `administradorFinca`.

Ara s’ha alineat amb el nou comportament:

* l’edifici es crea correctament;
* `administradorFinca` queda a `None`;
* la resposta indica `requereix_verificacio = true`;
* la gestió queda pendent d’una verificació documental aprovada.

---

## Validació executada

### System check

S’ha executat:

```bash
docker compose exec web python manage.py check
```

Resultat:

```text
System check identified no issues
```

---

### Comprovació de migracions

S’ha executat:

```bash
docker compose exec web python manage.py makemigrations --check --dry-run
```

Resultat:

```text
No changes detected
```

No s’han afegit migracions.

---

### Tests específics del fix

S’ha executat:

```bash
docker compose exec web python manage.py test apps.accounts.tests.PendingAdminVerificationAccessTests -v 2
```

Resultat:

```text
Ran 4 tests

OK
```

Tests validats:

```text
test_admin_finca_approved_pot_accedir_detail_edifici
test_admin_finca_pending_no_pot_accedir_detail_edifici
test_me_edificis_no_retorna_edifici_amb_verificacio_pending
test_owner_vinculat_no_es_bloqueja_per_verificacio_admin_pending
```

---

### Regressió d’accounts i verification

S’ha executat:

```bash
docker compose exec web python manage.py test apps.accounts apps.verification -v 2
```

Resultat:

```text
Ran 126 tests

OK
```

Aquesta regressió valida que el canvi no trenca:

* autenticació;
* OAuth;
* password reset;
* permisos d’usuari;
* `/me`;
* `/me/edificis/`;
* verificacions documentals;
* scoring documental;
* revisió i aprovació de verificacions;
* rebuig de verificacions;
* tests de concurrència d’accounts.

---

### Regressió de buildings

S’ha executat:

```bash
docker compose exec web python manage.py test apps.buildings -v 2
```

S’ha detectat un únic test antic que esperava el comportament anterior:

```text
TestAdminFincaAltaEdifici.test_crear_edifici_si_no_existeix
```

Aquest test s’ha actualitzat perquè ara el comportament correcte és que la creació d’un edifici no assigni `administradorFinca` immediatament.

Després d’actualitzar el test, la regressió de `apps.buildings` queda alineada amb la nova regla funcional.

---

## Impacte funcional

Amb aquest PR, el flux queda així:

### Abans de l’aprovació documental

Quan una verificació està en estat:

```text
pending
running
review
rejected
```

l’administrador de finca:

* no veu l’edifici com a administrat a `/api/accounts/me/edificis/`;
* no pot accedir al detall com a administrador de finca;
* no pot gestionar habitatges de l’edifici com a administrador;
* no pot accedir a accions reservades a l’administrador de finca;
* no pot operar com a administrador de l’edifici encara que hagi iniciat el procés de vinculació.

---

### Després de l’aprovació documental

Quan la verificació passa a:

```text
approved
```

el flux d’aprovació pot assignar:

```python
edifici.administradorFinca = user
```

i llavors:

* l’edifici apareix al perfil de l’administrador de finca;
* `/api/accounts/me/edificis/` retorna l’edifici;
* el detall de l’edifici és accessible;
* els permisos de gestió passen correctament;
* l’administrador de finca pot operar sobre l’edifici segons el seu rol.

---

### Assignacions històriques o manuals

Per evitar trencar dades existents, si un edifici ja té `administradorFinca` assignat però no existeix cap verificació documental associada a aquell usuari i edifici, l’assignació es manté com a vàlida.

Això permet conservar compatibilitat amb:

* dades de demo;
* dades històriques;
* assignacions fetes manualment per administradors de sistema;
* tests existents que no formen part del flux documental nou.

---

## Fitxers modificats

### Nou fitxer

```text
backend/apps/verification/access.py
```

Conté la lògica centralitzada d’accés efectiu segons verificació documental.

---

### Fitxers modificats

```text
backend/apps/accounts/permissions.py
backend/apps/accounts/views.py
backend/apps/accounts/tests.py
backend/apps/buildings/permissions.py
backend/apps/buildings/serializers.py
backend/apps/buildings/views.py
backend/apps/buildings/tests.py
backend/apps/verification/serializers.py
```

---

## Decisions tècniques

### Centralitzar la regla d’accés

S’ha preferit crear un helper centralitzat en lloc de duplicar condicions a cada view o permission.

Això redueix inconsistències i facilita mantenir una única regla clara:

```text
administrador de finca efectiu = administradorFinca assignat + verificació aprovada si existeix verificació documental
```

---

### Mantenir compatibilitat amb dades antigues

No s’ha fet que totes les assignacions existents requereixin verificació documental, perquè això podria bloquejar dades ja carregades, dades de demo o assignacions manuals fetes abans d’aquest flux.

Per això, el bloqueig només s’aplica quan existeix una verificació documental associada a aquell usuari i edifici.

---

### No afegir migracions

El canvi no modifica models ni estructura de base de dades.

És un canvi de:

* autorització;
* filtratge de querysets;
* permisos;
* serialització;
* tests.

Per això no s’han generat migracions.

---

## Risc i mitigació

### Risc

Aquest canvi afecta punts sensibles d’autorització i accés a edificis.

Podria impactar funcionalitats que assumeixen que `administradorFinca` implica accés immediat.

### Mitigació

S’han reforçat tests específics i regressió de les apps afectades.

A més, el helper manté compatibilitat amb assignacions sense verificació associada per no trencar dades històriques o de demo.

---

## Checklist de revisió

* [x] `/api/accounts/me/edificis/` no retorna edificis amb verificació pendent.
* [x] El detall d’edifici no és accessible com a admin finca si la verificació està pendent.
* [x] Una verificació `approved` sí que permet l’accés.
* [x] Owners i tenants vinculats no queden bloquejats per la verificació pendent de l’admin finca.
* [x] Crear un edifici com a admin finca no assigna `administradorFinca` immediatament.
* [x] Vincular-se a un edifici existent no concedeix gestió immediata.
* [x] `review` compta com a verificació activa per evitar duplicats.
* [x] No s’han afegit migracions.
* [x] `manage.py check` passa.
* [x] `makemigrations --check --dry-run` no detecta canvis.
* [x] Tests específics del fix passen.
* [x] Regressió d’`apps.accounts` i `apps.verification` passa.

---

## Notes per al reviewer

Aquest PR no canvia el model de dades.

La idea principal és separar clarament dos conceptes:

1. **Sol·licitud o procés documental iniciat**
2. **Administració efectiva de l’edifici**

Un administrador de finca pot iniciar una sol·licitud, però no ha de tenir accés real a l’edifici fins que la verificació documental estigui aprovada per l’administrador de sistema.

Això evita accessos prematurs i fa que el comportament sigui coherent amb el flux de validació documental.

```
```
