### PR TITLE
fix: automatitza snapshots i inclou Open Data al ranking de progrés

### DIFF
--- a/backend/apps/leagues/services.py
+++ b/backend/apps/leagues/services.py
@@ -1,0 +1,64 @@
+from django.db import transaction
+
+from apps.leagues.models import CategoriaRanking, Lliga, RankingHistorico
+from apps.participations.models import Participacio
+
+
+def generar_snapshots_temporada(temporada, categoria=CategoriaRanking.PROGRES):
+    """Genera o actualitza snapshots de RankingHistorico per una temporada.
+
+    Per defecte només consolida la categoria PROGRES, perquè el ranking final
+    del producte queda definit per les divisions Bronze/Silver/Gold de progrés.
+    És idempotent: si el snapshot ja existeix, s'actualitza.
+    """
+    lligues = (
+        Lliga.objects
+        .filter(temporada=temporada, categoria=categoria)
+        .order_by("id")
+    )
+
+    resum = {
+        "temporada": temporada.id_temporada,
+        "categoria": str(categoria),
+        "lligues_processades": 0,
+        "items": 0,
+    }
+
+    with transaction.atomic():
+        for lliga in lligues:
+            resum["lligues_processades"] += 1
+
+            participacions = (
+                Participacio.objects
+                .filter(lliga=lliga)
+                .select_related("edifici")
+                .order_by("-puntuacio", "edifici_id")
+            )
+
+            for posicio, participacio in enumerate(participacions, start=1):
+                update_fields = []
+
+                if participacio.posicio != posicio:
+                    participacio.posicio = posicio
+                    update_fields.append("posicio")
+
+                if participacio.divisio != lliga.divisio:
+                    participacio.divisio = lliga.divisio
+                    update_fields.append("divisio")
+
+                if update_fields:
+                    participacio.save(update_fields=update_fields)
+
+                RankingHistorico.objects.update_or_create(
+                    edifici=participacio.edifici,
+                    temporada=temporada,
+                    categoria=lliga.categoria,
+                    defaults={
+                        "puntuacio": participacio.puntuacio,
+                        "posicio": posicio,
+                        "divisio": lliga.divisio,
+                    },
+                )
+                resum["items"] += 1
+
+    return resum

--- a/backend/apps/leagues/views.py
+++ b/backend/apps/leagues/views.py
@@ -10,6 +10,8 @@ from .serializers import LligaSerializer
 from apps.buildings.models import GrupComparable
 from apps.participations.models import Participacio
 from apps.accounts.permissions import ABACMixin, IsAdminSistema
+from apps.seasons.models import Temporada, EstatTemporada
+from apps.leagues.services import generar_snapshots_temporada
 
 class LligaViewSet(viewsets.ModelViewSet):
     queryset = Lliga.objects.all()
@@ -117,6 +119,17 @@ class LligaViewSet(viewsets.ModelViewSet):
                 {"error": "edifici and categoria are required"},
                 status=status.HTTP_400_BAD_REQUEST
             )
+
+        # Snapshot on demand: si hi ha temporada activa, mantenim RankingHistorico
+        # actualitzat abans de retornar evolució.
+        temporada_activa = (
+            Temporada.objects
+            .filter(estat=EstatTemporada.ACTIVA)
+            .order_by("-dataInici", "-id_temporada")
+            .first()
+        )
+        if temporada_activa:
+            generar_snapshots_temporada(temporada_activa, categoria=categoria.upper())
 
         historial = RankingHistorico.objects.filter(
             edifici_id=edifici_id,

--- a/backend/apps/participations/managers.py
+++ b/backend/apps/participations/managers.py
@@ -5,17 +5,23 @@ from apps.buildings.models import EstatValidacio
 class ParticipationManager(models.Manager):
 
     def create_participation(self, edifici, lliga):
-        puntuacio_base = edifici.puntuacioBase or 0
+        """Crea una participació amb la puntuació efectiva de l'edifici.
 
-        puntuacio_millores = (
-                edifici.implementacions.filter(
-                    estatValidacio=EstatValidacio.VALIDADA
-                ).aggregate(
-                    total=Sum("millora__impactePunts")
-                )["total"] or 0
-        )
+        Prioritat:
+        1. puntuacioBase, si existeix.
+        2. puntuacioBaseOpenData, per edificis provinents de CEE/Open Data.
+        3. 0 si encara no hi ha dades suficients.
 
-        puntuacio_inicial = puntuacio_base + puntuacio_millores
+        No sumem aquí les millores validades perquè la consolidació de millores
+        es fa explícitament a l'inici de temporada actualitzant puntuacioBase.
+        Això evita dobles comptatges.
+        """
+        if edifici.puntuacioBase is not None:
+            puntuacio_inicial = edifici.puntuacioBase
+        elif edifici.puntuacioBaseOpenData is not None:
+            puntuacio_inicial = edifici.puntuacioBaseOpenData
+        else:
+            puntuacio_inicial = 0
 
         return self.create(
             edifici=edifici,

--- a/backend/apps/participations/views.py
+++ b/backend/apps/participations/views.py
@@ -132,17 +132,19 @@ class ParticipacioViewSet(viewsets.ModelViewSet):
         avui = timezone.now().date()
         fa_un_any = avui - timedelta(days=365)
 
-        participacions = (
+        participacions_qs = (
             Participacio.objects
             .select_related("lliga__temporada")
             .filter(
                 edifici_id=edifici_id,
                 lliga__temporada__dataInici__gte=fa_un_any
             )
-            .order_by("lliga__temporada__dataInici")
+            .order_by("lliga__temporada__dataInici", "lliga__temporada_id", "id")
         )
 
-        if not participacions.exists():
+        participacions = list(participacions_qs)
+
+        if not participacions:
             return Response(
                 {
                     "estat": "sense_dades",
@@ -151,11 +153,52 @@ class ParticipacioViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_200_OK
             )
 
+        # Pot existir més d'una participació del mateix edifici dins una mateixa
+        # temporada, especialment després d'afegir participacions automàtiques
+        # PROGRES per edificis sense puntuació inicial.
+        #
+        # Per calcular el progrés anual no volem que una participació automàtica
+        # amb puntuació 0 tapi una participació real ja existent de la mateixa
+        # temporada. Per això reduïm a una participació representativa per
+        # temporada i prioritzem la puntuació més alta.
+        participacions_per_temporada = {}
 
-        participacio_inicial = participacions.first()
+        for participacio in participacions:
+            temporada = participacio.lliga.temporada
+            temporada_id = temporada.id_temporada
+            actual = participacions_per_temporada.get(temporada_id)
 
+            if actual is None:
+                participacions_per_temporada[temporada_id] = participacio
+                continue
 
-        participacio_actual = participacions.last()
+            puntuacio_nova = participacio.puntuacio or 0
+            puntuacio_actual_guardada = actual.puntuacio or 0
+
+            if puntuacio_nova > puntuacio_actual_guardada:
+                participacions_per_temporada[temporada_id] = participacio
+                continue
+
+            # Si empaten en puntuació, preferim PROGRES perquè és la categoria
+            # de rànquing vigent del MVP. Si cap és PROGRES, mantenim l'existent.
+            if (
+                puntuacio_nova == puntuacio_actual_guardada
+                and participacio.lliga.categoria == "PROGRES"
+                and actual.lliga.categoria != "PROGRES"
+            ):
+                participacions_per_temporada[temporada_id] = participacio
+
+        participacions_representatives = sorted(
+            participacions_per_temporada.values(),
+            key=lambda p: (
+                p.lliga.temporada.dataInici,
+                p.lliga.temporada.id_temporada,
+                p.id,
+            )
+        )
+
+        participacio_inicial = participacions_representatives[0]
+        participacio_actual = participacions_representatives[-1]
 
         puntuacio_inicial = participacio_inicial.puntuacio
         puntuacio_actual = participacio_actual.puntuacio

--- a/backend/apps/seasons/managers.py
+++ b/backend/apps/seasons/managers.py
@@ -8,16 +8,31 @@ class SeasonManager(models.Manager):
         return self.create(nom=nom, dataInici=dataInici, dataFi=dataFi)
 
     def iniciar(self, temporada):
+        from django.db import transaction
         from .models import EstatTemporada
+        from apps.leagues.services import generar_snapshots_temporada
+
         if temporada.estat != EstatTemporada.PENDENT:
             raise ValueError(
                 f"No es pot iniciar una temporada en estat '{temporada.estat}'. "
                 "Només es poden iniciar temporades en estat PENDENT."
             )
-        if self.filter(estat=EstatTemporada.ACTIVA).exists():
-            raise ValueError("Ja existeix una temporada activa. Tanca-la primer.")
-        temporada.estat = EstatTemporada.ACTIVA
-        temporada.save()
+
+        with transaction.atomic():
+            temporades_actives = (
+                self.select_for_update()
+                .filter(estat=EstatTemporada.ACTIVA)
+                .exclude(pk=temporada.pk)
+            )
+
+            for activa in temporades_actives:
+                # Abans de tancar automàticament l'anterior, consolidem el seu històric.
+                generar_snapshots_temporada(activa)
+                activa.estat = EstatTemporada.TANCADA
+                activa.save(update_fields=["estat"])
+
+            temporada.estat = EstatTemporada.ACTIVA
+            temporada.save(update_fields=["estat"])
 
     def tancar(self, temporada):
         from .models import EstatTemporada

--- a/backend/apps/seasons/managers.py
+++ b/backend/apps/seasons/managers.py
@@ -21,11 +21,18 @@ class SeasonManager(models.Manager):
 
     def tancar(self, temporada):
         from .models import EstatTemporada
+        from apps.leagues.services import generar_snapshots_temporada
+
         if temporada.estat != EstatTemporada.ACTIVA:
             raise ValueError(
                 f"No es pot tancar una temporada en estat '{temporada.estat}'. "
                 "Només es poden tancar temporades en estat ACTIVA."
             )
+
+        # Consolidar RankingHistorico abans de tancar la temporada.
+        # Per decisió de producte només es consolida la categoria PROGRES.
+        generar_snapshots_temporada(temporada)
+
         temporada.estat = EstatTemporada.TANCADA
         temporada.save()
 

--- a/backend/apps/seasons/services.py
+++ b/backend/apps/seasons/services.py
@@ -76,7 +76,10 @@ def _actualitzar_participacions_temporada(temporada: Temporada, edifici: Edifici
     return (
         Participacio.objects
         .filter(lliga__temporada=temporada, edifici=edifici)
-        .update(puntuacio=puntuacio)
+        .update(
+            puntuacio=puntuacio,
+            puntuacio_inicial=puntuacio,
+        )
     )
 
 

--- a/backend/apps/seasons/signals.py
+++ b/backend/apps/seasons/signals.py
@@ -10,25 +10,38 @@ from apps.participations.models import Participacio
 logger = logging.getLogger(__name__)
 
 def _puntuacio_efectiva(edifici):
-    """Retorna puntuacioBase si existeix, sinó puntuacioBaseOpenData."""
+    """Retorna la puntuació efectiva de l'edifici.
+
+    Prioritat:
+    1. puntuacioBase, si existeix.
+    2. puntuacioBaseOpenData, si ve de CEE/Open Data.
+    3. 0 si encara no té dades suficients.
+
+    Els edificis sense puntuació també entren a la temporada perquè poden
+    incorporar habitatges o dades durant la temporada i començar a progressar.
+    """
     if edifici.puntuacioBase is not None:
         return edifici.puntuacioBase
-    return edifici.puntuacioBaseOpenData
+    if edifici.puntuacioBaseOpenData is not None:
+        return edifici.puntuacioBaseOpenData
+    return 0
 
-def _assignar_divisio_per_percentil(puntuacio, llindars):
+def _assignar_divisio_per_index(index, total):
+    """Assigna divisió repartint la temporada en terços per ordre de puntuació.
+
+    Això evita que molts edificis empatats a 0 acabin tots a la mateixa divisió
+    només perquè els llindars percentils són iguals.
     """
-    llindars = (p33, p66)
-    < p33  → Bronze
-    < p66  → Silver
-    >= p66 → Gold
-    """
-    p33, p66 = llindars
-    if puntuacio >= p66:
+    if total <= 1:
         return "Gold"
-    elif puntuacio >= p33:
-        return "Silver"
-    else:
+
+    ratio = (index + 1) / total
+
+    if ratio <= 1 / 3:
         return "Bronze"
+    if ratio <= 2 / 3:
+        return "Silver"
+    return "Gold"
 
 
 @receiver(post_save, sender=Temporada)
@@ -42,7 +55,7 @@ def crear_lligues_i_participacions(sender, instance, **kwargs):
     # ── 1. Crear lligues ────────────────────────────────────────────────────
     if not Lliga.objects.filter(temporada=instance).exists():
         Lliga.objects.create_progress_leagues(instance)
-        logger.info(f"[SIGNAL] 9 lligues creades")
+        logger.info(f"[SIGNAL] 3 lligues PROGRES creades")
     else:
         logger.info(f"[SIGNAL] Lligues ja existien")
 
@@ -54,39 +67,33 @@ def crear_lligues_i_participacions(sender, instance, **kwargs):
     }
     logger.info(f"[SIGNAL] Lligues PROGRES: {lligues_progres}")
 
-    # ── 3. Edificis actius amb almenys una puntuació ────────────────────────
-    from django.db.models import Q
-    edificis = list(
-        Edifici.actius
-        .filter(
-            Q(puntuacioBase__isnull=False) | Q(puntuacioBaseOpenData__isnull=False)
-        )
-        .order_by("puntuacioBase", "puntuacioBaseOpenData")  # nulls al final
-    )
+    # ── 3. Edificis actius ─────────────────────────────────────────────────
+    # Entren tots els edificis actius, encara que ara mateix no tinguin score.
+    # Si encara no tenen puntuació, comencen amb 0 i poden progressar durant la temporada.
+    edificis = list(Edifici.actius.all())
 
     if not edificis:
-        logger.warning("Cap edifici actiu amb puntuació per assignar a la temporada id=%s.", instance.pk)
+        logger.warning("Cap edifici actiu per assignar a la temporada id=%s.", instance.pk)
         return
 
-    # ── 4. Percentils sobre puntuació efectiva ──────────────────────────────
-    puntuacions = sorted([_puntuacio_efectiva(e) for e in edificis])
-    n = len(puntuacions)
-    p33 = puntuacions[int(n * 0.33)]
-    p66 = puntuacions[int(n * 0.66)]
+    edificis_ordenats = sorted(
+        edificis,
+        key=lambda edifici: (_puntuacio_efectiva(edifici), edifici.pk),
+    )
+    n = len(edificis_ordenats)
 
     logger.info(
-        "Temporada id=%s — %d edificis. Llindars: p33=%.2f, p66=%.2f",
-        instance.pk, n, p33, p66
+        "Temporada id=%s — %d edificis actius assignables a PROGRES.",
+        instance.pk, n
     )
 
-    # ── 5. Crear participacions ─────────────────────────────────────────────
+    # ── 4. Crear participacions ─────────────────────────────────────────────
     creades = 0
-    for edifici in edificis:
+    for index, edifici in enumerate(edificis_ordenats):
         if Participacio.objects.filter(edifici=edifici, lliga__temporada=instance).exists():
             continue
 
-        puntuacio = _puntuacio_efectiva(edifici)
-        divisio = _assignar_divisio_per_percentil(puntuacio, (p33, p66))
+        divisio = _assignar_divisio_per_index(index, n)
         lliga = lligues_progres[divisio]
         Participacio.objects.create_participation(edifici=edifici, lliga=lliga)
         creades += 1

--- a/backend/apps/seasons/tests.py
+++ b/backend/apps/seasons/tests.py
@@ -57,13 +57,20 @@ class EstatTemporadaManagerTest(TestCase):
         with self.assertRaises(ValueError):
             Temporada.objects.iniciar(self.temporada)
 
-    def test_iniciar_quan_ja_existeix_activa_falla(self):
+    def test_iniciar_quan_ja_existeix_activa_tanca_anterior(self):
         Temporada.objects.iniciar(self.temporada)
         altra = Temporada.objects.create(
             nom='Altra temporada', dataInici='2027-01-01', dataFi='2027-12-31'
         )
-        with self.assertRaises(ValueError):
-            Temporada.objects.iniciar(altra)
+
+        Temporada.objects.iniciar(altra)
+
+        self.temporada.refresh_from_db()
+        altra.refresh_from_db()
+
+        self.assertEqual(self.temporada.estat, EstatTemporada.TANCADA)
+        self.assertEqual(altra.estat, EstatTemporada.ACTIVA)
+        self.assertEqual(Temporada.objects.filter(estat=EstatTemporada.ACTIVA).count(), 1)
 
     def test_tancar_temporada_activa(self):
         Temporada.objects.iniciar(self.temporada)
@@ -170,14 +177,21 @@ class TemporadaAPITest(APITestCase):
         response = self.client.post(f'/api/seasons/{self.temporada.pk}/iniciar/')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_iniciar_quan_ja_hi_ha_activa_retorna_400(self):
+    def test_iniciar_quan_ja_hi_ha_activa_tanca_anterior(self):
         self.client.force_authenticate(user=self.admin)
         self.client.post(f'/api/seasons/{self.temporada.pk}/iniciar/')
         altra = Temporada.objects.create(
             nom='Altra temporada', dataInici='2027-01-01', dataFi='2027-12-31'
         )
+
         response = self.client.post(f'/api/seasons/{altra.pk}/iniciar/')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.temporada.refresh_from_db()
+        altra.refresh_from_db()
+        self.assertEqual(self.temporada.estat, EstatTemporada.TANCADA)
+        self.assertEqual(altra.estat, EstatTemporada.ACTIVA)
+        self.assertEqual(Temporada.objects.filter(estat=EstatTemporada.ACTIVA).count(), 1)
 
     def test_usuari_no_admin_no_pot_iniciar(self):
         self.client.force_authenticate(user=self.user)
@@ -1012,12 +1026,13 @@ class TemporadaOpenDataSnapshotsAPITest(APITestCase):
         self.assertEqual(participacio_od.puntuacio, 55)
         self.assertEqual(participacio_od.puntuacio_inicial, 55)
 
-        self.assertFalse(
-            Participacio.objects.filter(
-                edifici=edifici_sense_score,
-                lliga__temporada=temporada,
-            ).exists()
+        participacio_sense_score = Participacio.objects.get(
+            edifici=edifici_sense_score,
+            lliga__temporada=temporada,
         )
+
+        self.assertEqual(participacio_sense_score.puntuacio, 0)
+        self.assertEqual(participacio_sense_score.puntuacio_inicial, 0)
 
     def test_generar_snapshot_temporada_es_idempotent(self):
         temporada = Temporada.objects.create(
@@ -1137,3 +1152,83 @@ class TemporadaOpenDataSnapshotsAPITest(APITestCase):
             ).count(),
             1,
         )
+
+    def test_crear_i_iniciar_tanca_temporada_activa_anterior(self):
+        self._crear_edifici(
+            "Carrer Activa Anterior",
+            40,
+            puntuacio_base=71,
+        )
+        activa = Temporada.objects.create(
+            nom="Temporada Activa Anterior",
+            dataInici="2031-01-01",
+            dataFi="2031-12-31",
+        )
+        Temporada.objects.iniciar(activa)
+
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.post("/api/seasons/crear-i-iniciar/", {
+            "nom": "Temporada Nova Activa",
+            "dataInici": "2032-01-01",
+            "dataFi": "2032-12-31",
+        })
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        activa.refresh_from_db()
+        self.assertEqual(activa.estat, EstatTemporada.TANCADA)
+        self.assertEqual(response.data["estat"], EstatTemporada.ACTIVA)
+        self.assertEqual(Temporada.objects.filter(estat=EstatTemporada.ACTIVA).count(), 1)
+
+    def test_ranking_progres_genera_snapshot_on_demand(self):
+        temporada = Temporada.objects.create(
+            nom="Temporada Ranking On Demand",
+            dataInici="2033-01-01",
+            dataFi="2033-12-31",
+        )
+        edifici = self._crear_edifici(
+            "Carrer Ranking Demand",
+            50,
+            puntuacio_base=73,
+        )
+
+        Temporada.objects.iniciar(temporada)
+        RankingHistorico.objects.filter(temporada=temporada).delete()
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"/api/seasons/{temporada.pk}/ranking/progres/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            RankingHistorico.objects.filter(
+                edifici=edifici,
+                temporada=temporada,
+                categoria="PROGRES",
+            ).count(),
+            1,
+        )
+
+    def test_evolucio_genera_snapshot_on_demand(self):
+        temporada = Temporada.objects.create(
+            nom="Temporada Evolucio On Demand",
+            dataInici="2034-01-01",
+            dataFi="2034-12-31",
+        )
+        edifici = self._crear_edifici(
+            "Carrer Evolucio Demand",
+            60,
+            puntuacio_base=64,
+        )
+
+        Temporada.objects.iniciar(temporada)
+        RankingHistorico.objects.filter(temporada=temporada).delete()
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(
+            f"/api/leagues/evolucio/?edifici={edifici.idEdifici}&categoria=PROGRES"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["temporada"], temporada.id_temporada)
+        self.assertEqual(response.data[0]["puntuacio"], 64)

--- a/backend/apps/seasons/tests.py
+++ b/backend/apps/seasons/tests.py
@@ -921,3 +921,219 @@ class TemporadaRankingProgresAPITest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data['error'], 'window must be a positive integer')
+
+
+
+class TemporadaOpenDataSnapshotsAPITest(APITestCase):
+    """Regressió de temporada: Open Data, lligues de progrés i snapshots."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = make_superuser(email="season-opendata-admin@example.com")
+        self.user = make_user(email="season-opendata-user@example.com")
+
+        self.group = GrupComparable.objects.create(
+            idGrup=501,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="100-200",
+        )
+
+    def _crear_edifici(self, carrer, numero, puntuacio_base=None, puntuacio_od=None, font_open_data=False):
+        loc = Localitzacio.objects.create(
+            carrer=carrer,
+            numero=numero,
+            codiPostal="08001",
+            barri="Eixample",
+        )
+        return Edifici.objects.create(
+            anyConstruccio=1990,
+            tipologia="Residencial",
+            superficieTotal=120,
+            nombrePlantes=4,
+            reglament="Desconegut",
+            orientacioPrincipal="Sud",
+            grupComparable=self.group,
+            localitzacio=loc,
+            puntuacioBase=puntuacio_base,
+            puntuacioBaseOpenData=puntuacio_od,
+            font_open_data=font_open_data,
+        )
+
+    def test_iniciar_temporada_crea_només_lligues_progres_i_inclou_opendata(self):
+        temporada = Temporada.objects.create(
+            nom="Temporada Open Data",
+            dataInici="2027-01-01",
+            dataFi="2027-12-31",
+        )
+
+        edifici_manual = self._crear_edifici(
+            "Carrer Manual",
+            1,
+            puntuacio_base=80,
+        )
+        edifici_opendata = self._crear_edifici(
+            "Carrer CEE",
+            2,
+            puntuacio_od=55,
+            font_open_data=True,
+        )
+        edifici_sense_score = self._crear_edifici(
+            "Carrer Sense Score",
+            3,
+        )
+
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.post(f"/api/seasons/{temporada.pk}/iniciar/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.assertEqual(
+            Lliga.objects.filter(temporada=temporada, categoria="PROGRES").count(),
+            3,
+        )
+        self.assertEqual(
+            Lliga.objects.filter(temporada=temporada, categoria__in=["EFICIENCIA", "RESILIENCIA"]).count(),
+            0,
+        )
+
+        participacio_manual = Participacio.objects.get(
+            edifici=edifici_manual,
+            lliga__temporada=temporada,
+        )
+        participacio_od = Participacio.objects.get(
+            edifici=edifici_opendata,
+            lliga__temporada=temporada,
+        )
+
+        self.assertEqual(participacio_manual.puntuacio, 80)
+        self.assertEqual(participacio_manual.puntuacio_inicial, 80)
+
+        self.assertEqual(participacio_od.puntuacio, 55)
+        self.assertEqual(participacio_od.puntuacio_inicial, 55)
+
+        self.assertFalse(
+            Participacio.objects.filter(
+                edifici=edifici_sense_score,
+                lliga__temporada=temporada,
+            ).exists()
+        )
+
+    def test_generar_snapshot_temporada_es_idempotent(self):
+        temporada = Temporada.objects.create(
+            nom="Temporada Snapshot",
+            dataInici="2028-01-01",
+            dataFi="2028-12-31",
+        )
+        edifici = self._crear_edifici(
+            "Carrer Snapshot",
+            10,
+            puntuacio_base=70,
+        )
+
+        Temporada.objects.iniciar(temporada)
+
+        from apps.leagues.services import generar_snapshots_temporada
+
+        resum_1 = generar_snapshots_temporada(temporada)
+        resum_2 = generar_snapshots_temporada(temporada)
+
+        self.assertEqual(resum_1["items"], 1)
+        self.assertEqual(resum_2["items"], 1)
+        self.assertEqual(
+            RankingHistorico.objects.filter(
+                edifici=edifici,
+                temporada=temporada,
+                categoria="PROGRES",
+            ).count(),
+            1,
+        )
+
+    def test_tancar_temporada_genera_snapshot_automaticament(self):
+        temporada = Temporada.objects.create(
+            nom="Temporada Tancar Snapshot",
+            dataInici="2029-01-01",
+            dataFi="2029-12-31",
+        )
+        edifici = self._crear_edifici(
+            "Carrer Tancar",
+            20,
+            puntuacio_base=60,
+        )
+
+        Temporada.objects.iniciar(temporada)
+        participacio = Participacio.objects.get(
+            edifici=edifici,
+            lliga__temporada=temporada,
+        )
+        participacio.puntuacio = 88
+        participacio.save(update_fields=["puntuacio"])
+
+        Temporada.objects.tancar(temporada)
+
+        snapshot = RankingHistorico.objects.get(
+            edifici=edifici,
+            temporada=temporada,
+            categoria="PROGRES",
+        )
+
+        self.assertEqual(snapshot.puntuacio, 88)
+        self.assertEqual(snapshot.posicio, 1)
+        self.assertEqual(snapshot.divisio, participacio.divisio)
+
+    def test_endpoint_anteriors_retorna_només_temporades_tancades(self):
+        tancada = Temporada.objects.create(
+            nom="Temporada Tancada",
+            dataInici="2024-01-01",
+            dataFi="2024-12-31",
+            estat="TANCADA",
+        )
+        Temporada.objects.create(
+            nom="Temporada Pendent",
+            dataInici="2025-01-01",
+            dataFi="2025-12-31",
+            estat="PENDENT",
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get("/api/seasons/anteriors/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual([item["id_temporada"] for item in response.data], [tancada.id_temporada])
+
+    def test_admin_pot_crear_i_iniciar_temporada_en_un_sol_endpoint(self):
+        self._crear_edifici(
+            "Carrer Crear Iniciar",
+            30,
+            puntuacio_base=66,
+        )
+
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.post("/api/seasons/crear-i-iniciar/", {
+            "nom": "Temporada Crear I Iniciar",
+            "dataInici": "2030-01-01",
+            "dataFi": "2030-12-31",
+        })
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["estat"], EstatTemporada.ACTIVA)
+        self.assertEqual(
+            Lliga.objects.filter(
+                temporada_id=response.data["id_temporada"],
+                categoria="PROGRES",
+            ).count(),
+            3,
+        )
+        self.assertEqual(
+            Participacio.objects.filter(
+                lliga__temporada_id=response.data["id_temporada"],
+            ).count(),
+            1,
+        )
+        self.assertEqual(
+            RankingHistorico.objects.filter(
+                temporada_id=response.data["id_temporada"],
+                categoria="PROGRES",
+            ).count(),
+            1,
+        )

--- a/backend/apps/seasons/views.py
+++ b/backend/apps/seasons/views.py
@@ -12,7 +12,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.exceptions import NotFound
 
 from apps.accounts.permissions import IsAdminSistema
-from .models import Temporada
+from .models import Temporada, EstatTemporada
 from .serializers import TemporadaSerializer
 from .services import actualitzar_puntuacions_base_inici_temporada
 from apps.participations.models import Participacio
@@ -161,6 +161,12 @@ class TemporadaViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["get"], url_path="ranking/progres")
     def ranking_progres(self, request, pk=None):
         temporada = self.get_object()
+
+        # Snapshot on demand: si es consulta el progrés de la temporada activa,
+        # actualitzem RankingHistorico abans de llegir-lo.
+        if temporada.estat == EstatTemporada.ACTIVA:
+            generar_snapshots_temporada(temporada)
+
         window = request.query_params.get("window", 5)
 
         try:

--- a/backend/apps/seasons/views.py
+++ b/backend/apps/seasons/views.py
@@ -1,4 +1,5 @@
 from django.db.models import Q
+from django.db import transaction
 from django.db.models import F
 from django.db.models.functions import Rank
 from django.db.models.expressions import Window
@@ -17,6 +18,7 @@ from .services import actualitzar_puntuacions_base_inici_temporada
 from apps.participations.models import Participacio
 from apps.participations.serializers import RankingSerializer
 from apps.leagues.models import Lliga, RankingHistorico
+from apps.leagues.services import generar_snapshots_temporada
 from apps.buildings.models import GrupComparable
 from apps.leagues.pagination import RankingPagination
 
@@ -27,9 +29,50 @@ class TemporadaViewSet(viewsets.ModelViewSet):
     permission_classes=[IsAuthenticated]
 
     def get_permissions(self):
-        if self.action in ['list', 'retrieve', 'ranking', 'ranking_progres', 'posicio_edifici']:
+        if self.action in [
+            'list',
+            'retrieve',
+            'ranking',
+            'ranking_progres',
+            'posicio_edifici',
+            'anteriors',
+            'previous',
+        ]:
             return [IsAuthenticated()]
         return [IsAdminSistema()]
+
+    @action(detail=False, methods=['post'], url_path='crear-i-iniciar')
+    def crear_i_iniciar(self, request):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            with transaction.atomic():
+                temporada = serializer.save()
+                Temporada.objects.iniciar(temporada)
+                resum_puntuacions = actualitzar_puntuacions_base_inici_temporada(temporada)
+                resum_snapshot = generar_snapshots_temporada(temporada)
+                temporada.refresh_from_db()
+        except ValueError as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        data = TemporadaSerializer(temporada).data
+        data["resum_puntuacions_base"] = resum_puntuacions
+        data["resum_snapshot_ranking"] = resum_snapshot
+        return Response(data, status=status.HTTP_201_CREATED)
+
+    @action(detail=False, methods=['get'], url_path='anteriors')
+    def anteriors(self, request):
+        temporades = (
+            Temporada.objects
+            .filter(estat='TANCADA')
+            .order_by("-dataInici", "-id_temporada")
+        )
+        return Response(TemporadaSerializer(temporades, many=True).data)
+
+    @action(detail=False, methods=['get'], url_path='previous')
+    def previous(self, request):
+        return self.anteriors(request)
 
     @action(detail=True, methods=['post'], url_path='iniciar')
     def iniciar(self, request, pk=None):
@@ -37,12 +80,14 @@ class TemporadaViewSet(viewsets.ModelViewSet):
         try:
             Temporada.objects.iniciar(temporada)
             resum_puntuacions = actualitzar_puntuacions_base_inici_temporada(temporada)
+            resum_snapshot = generar_snapshots_temporada(temporada)
             temporada.refresh_from_db()
         except ValueError as e:
             return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         data = TemporadaSerializer(temporada).data
         data["resum_puntuacions_base"] = resum_puntuacions
+        data["resum_snapshot_ranking"] = resum_snapshot
         return Response(data)
 
     @action(detail=True, methods=['post'], url_path='tancar')


### PR DESCRIPTION
## Resum

Aquest PR completa i reforça el flux de temporades, lligues i ranking de progrés.

L’objectiu és assegurar que el ranking de progrés funcioni de manera automàtica i coherent quan es crea, s’inicia, es consulta o es tanca una temporada.

Amb aquest canvi:

- es manté el criteri de producte actual: només es creen lligues de categoria `PROGRES`;
- les divisions són `Bronze`, `Silver` i `Gold`;
- els edificis Open Data / CEE entren al ranking amb `puntuacioBaseOpenData`;
- els edificis sense puntuació també entren a la temporada amb puntuació inicial `0`;
- els snapshots de `RankingHistorico` es generen automàticament;
- el ranking de progrés deixa de dependre d’un pas manual;
- consultar ranking/evolució pot generar snapshot on demand;
- iniciar una nova temporada tanca automàticament la temporada activa anterior;
- s’afegeixen endpoints per crear/iniciar temporada i consultar temporades anteriors;
- es reforça el càlcul de progrés anual quan hi ha múltiples participacions del mateix edifici en una temporada.

---

## Context

Després de revisar el flux de temporades, lligues i ranking de progrés, ja existia una base funcional important:

- en iniciar una temporada es creaven lligues de progrés;
- es creaven participacions per edificis elegibles;
- es repartien participacions entre `Bronze`, `Silver` i `Gold`;
- el ranking de progrés podia consultar `RankingHistorico`.

El que faltava reforçar era:

1. Que els edificis provinents d’Open Data / CEE entressin correctament al ranking.
2. Que els edificis encara sense puntuació també poguessin participar, començant amb `0`, perquè poden afegir habitatges o dades durant la temporada i progressar.
3. Que `RankingHistorico` es generés automàticament dins del flux de temporada.
4. Que el ranking de progrés pogués actualitzar snapshots en el moment de consulta.
5. Que iniciar una nova temporada no fallés per l’existència d’una activa, sinó que tanqués l’anterior automàticament.
6. Que el càlcul de progrés anual no quedés contaminat per participacions automàtiques de puntuació inferior dins la mateixa temporada.

---

## Decisió funcional

Per decisió de producte, en aquest moment només es treballa amb la categoria de ranking:

```text
PROGRES