### PR TITLE
docs: afegir Swagger UI i generació d’esquema OpenAPI

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -86,6 +86,7 @@ INSTALLED_APPS = [
     'apps.notifications',
 
     'apps.audit',
+    "drf_spectacular",
 ]
 
 MIDDLEWARE = [
@@ -202,7 +203,8 @@ REST_FRAMEWORK = {
         'login': '3/min',          # Login: 3 intentos/min por IP → previene credential stuffing
         'register': '5/hour',      # Register: 5 registros/hora por IP → evita account enumeration
         'refresh': '20/min',       # Refresh: 20 req/min → uso normal sin abuse
-    }
+    },
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 
 AUTH_USER_MODEL = 'accounts.User'

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -19,6 +19,7 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.views.generic import RedirectView
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 
 from apps.buildings.views import ThirdPartyServiceView
@@ -37,6 +38,8 @@ urlpatterns = [
     path("api/community/", include("apps.community.urls")),
     path("api/notifications/", include("apps.notifications.urls")),
     path('api/audit/', include('apps.audit.urls')),
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("api/swagger/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
 ]
 
 if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:

--- a/backend/docs/api/api.yml
+++ b/backend/docs/api/api.yml
@@ -1,0 +1,4842 @@
+openapi: 3.0.3
+info:
+  title: ''
+  version: 0.0.0
+paths:
+  /api/accounts/edificis/{id_edifici}/assignar-admin/:
+    patch:
+      operationId: accounts_edificis_assignar_admin_partial_update
+      parameters:
+      - in: path
+        name: id_edifici
+        schema:
+          type: integer
+        required: true
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/habitatges/{ref_cadastral}/assignar-resident/:
+    patch:
+      operationId: accounts_habitatges_assignar_resident_partial_update
+      description: |-
+        Mixin per a vistes DRF que necessiten validació ABAC.
+
+        Ús a la vista:
+            class MevaVista(ABACMixin, APIView):
+                def get(self, request, edifici_id):
+                    self.check_edifici_access(request, edifici_id)
+                    ...
+      parameters:
+      - in: path
+        name: ref_cadastral
+        schema:
+          type: string
+        required: true
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/login/:
+    post:
+      operationId: accounts_login_create
+      tags:
+      - accounts
+      security:
+      - {}
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/logout/:
+    post:
+      operationId: accounts_logout_create
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/me/:
+    get:
+      operationId: accounts_me_retrieve
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+    put:
+      operationId: accounts_me_update
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+    patch:
+      operationId: accounts_me_partial_update
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/me/edificis/:
+    get:
+      operationId: accounts_me_edificis_retrieve
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/me/role/:
+    patch:
+      operationId: accounts_me_role_partial_update
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/oauth/google/:
+    post:
+      operationId: accounts_oauth_google_create
+      tags:
+      - accounts
+      security:
+      - {}
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/password-reset/:
+    post:
+      operationId: accounts_password_reset_create
+      tags:
+      - accounts
+      security:
+      - {}
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/password-reset-confirm/:
+    post:
+      operationId: accounts_password_reset_confirm_create
+      tags:
+      - accounts
+      security:
+      - {}
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/refresh/:
+    post:
+      operationId: accounts_refresh_create
+      description: |-
+        Takes a refresh type JSON web token and returns an access type JSON web
+        token if the refresh token is valid.
+      tags:
+      - accounts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenRefresh'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TokenRefresh'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TokenRefresh'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenRefresh'
+          description: ''
+  /api/accounts/register/:
+    post:
+      operationId: accounts_register_create
+      tags:
+      - accounts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Register'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Register'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Register'
+        required: true
+      security:
+      - {}
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Register'
+          description: ''
+  /api/accounts/users/:
+    get:
+      operationId: accounts_users_list
+      description: Llista tots els usuaris de la plataforma.
+      tags:
+      - accounts
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserAdmin'
+          description: ''
+  /api/accounts/users/{id}/:
+    get:
+      operationId: accounts_users_retrieve
+      description: Detall d'un usuari concret.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - accounts
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAdmin'
+          description: ''
+  /api/accounts/users/{id}/block/:
+    post:
+      operationId: accounts_users_block_create
+      description: |-
+        Bloqueja permanentment un compte.
+        Revoca immediatament totes les sessions actives de l'usuari.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/users/{id}/suspend/:
+    post:
+      operationId: accounts_users_suspend_create
+      description: |-
+        Suspèn temporalment un compte.
+        Camps opcionals: reason (text), suspended_until (datetime; null = indefinit).
+        Revoca immediatament totes les sessions actives.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/users/{id}/unblock/:
+    post:
+      operationId: accounts_users_unblock_create
+      description: Desbloqueja un compte i el torna a l'estat actiu.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+  /api/accounts/users/{id}/unsuspend/:
+    post:
+      operationId: accounts_users_unsuspend_create
+      description: Aixeca la suspensió d'un compte i el torna a l'estat actiu.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - accounts
+      responses:
+        '200':
+          description: No response body
+  /api/audit/logs/:
+    get:
+      operationId: audit_logs_list
+      description: |-
+        GET /api/audit/logs/
+
+        Paràmetres de filtratge (query params):
+          - user_id       : filtra per usuari
+          - method        : GET, POST, PUT, PATCH, DELETE
+          - resource_type : buildings, accounts, verification...
+          - status_code   : codi de resposta HTTP
+          - from_date     : ISO 8601, ex. 2026-05-01
+          - to_date       : ISO 8601, ex. 2026-05-31
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - audit
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedAuditLogList'
+          description: ''
+  /api/buildings/admin-finca/edificis/alta/:
+    post:
+      operationId: buildings_admin_finca_edificis_alta_create
+      tags:
+      - buildings
+      responses:
+        '200':
+          description: No response body
+  /api/buildings/carrers/autocomplete/:
+    get:
+      operationId: buildings_carrers_autocomplete_retrieve
+      description: |-
+        Suggeriments de carrers per al formulari d'alta d'edifici.
+
+        La cerca és tolerant:
+        - cerca a nom_oficial i nom_curt
+        - ignora paraules habituals com "carrer", "de", "avinguda"
+        - retorna codi_via i codi_carrer_ine per facilitar depuració
+      tags:
+      - buildings
+      responses:
+        '200':
+          description: No response body
+  /api/buildings/dades_energetiques/:
+    get:
+      operationId: buildings_dades_energetiques_list
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DadesEnergetiques'
+          description: ''
+    post:
+      operationId: buildings_dades_energetiques_create
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DadesEnergetiques'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/DadesEnergetiques'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/DadesEnergetiques'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DadesEnergetiques'
+          description: ''
+  /api/buildings/dades_energetiques/{id}/:
+    get:
+      operationId: buildings_dades_energetiques_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this dades energetiques.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DadesEnergetiques'
+          description: ''
+    put:
+      operationId: buildings_dades_energetiques_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this dades energetiques.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DadesEnergetiques'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/DadesEnergetiques'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/DadesEnergetiques'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DadesEnergetiques'
+          description: ''
+    patch:
+      operationId: buildings_dades_energetiques_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this dades energetiques.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedDadesEnergetiques'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedDadesEnergetiques'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedDadesEnergetiques'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DadesEnergetiques'
+          description: ''
+    delete:
+      operationId: buildings_dades_energetiques_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this dades energetiques.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '204':
+          description: No response body
+  /api/buildings/edificis/:
+    get:
+      operationId: buildings_edificis_list
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EdificiList'
+          description: ''
+    post:
+      operationId: buildings_edificis_create
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/:
+    get:
+      operationId: buildings_edificis_retrieve
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+    put:
+      operationId: buildings_edificis_update
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+    patch:
+      operationId: buildings_edificis_partial_update
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedEdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedEdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedEdificiDetail'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+    delete:
+      operationId: buildings_edificis_destroy
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '204':
+          description: No response body
+  /api/buildings/edificis/{idEdifici}/badges/:
+    get:
+      operationId: buildings_edificis_badges_retrieve
+      description: |-
+        Retorna les insígnies assignades a l'edifici.
+
+        Si s'indica ?temporada=<id>, es retornen:
+        - insígnies permanents de l'edifici
+        - insígnies estacionals d'aquella temporada
+
+        Sense filtre de temporada, es retornen totes les assignacions visibles.
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/badges/recalcular/:
+    post:
+      operationId: buildings_edificis_badges_recalcular_create
+      description: |-
+        Recalcula les insígnies de l'edifici.
+
+        Només ho pot fer:
+        - administrador de sistema / staff / superuser
+        - administrador de finca de l'edifici
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/dades_energetiques/:
+    get:
+      operationId: buildings_edificis_dades_energetiques_retrieve
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/desactivar/:
+    post:
+      operationId: buildings_edificis_desactivar_create
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/habitatges/:
+    get:
+      operationId: buildings_edificis_habitatges_retrieve
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/habitatges/{referenciaCadastral}/:
+    get:
+      operationId: buildings_edificis_habitatges_retrieve_2
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      - in: path
+        name: referenciaCadastral
+        schema:
+          type: string
+          pattern: ^[A-Za-z0-9]+$
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/me/habitatge/{referenciaCadastral}/:
+    patch:
+      operationId: buildings_edificis_me_habitatge_partial_update
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      - in: path
+        name: referenciaCadastral
+        schema:
+          type: string
+          pattern: ^[A-Za-z0-9]+$
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedEdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedEdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedEdificiDetail'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/millores-implementades/:
+    get:
+      operationId: buildings_edificis_millores_implementades_retrieve
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/reactivar/:
+    post:
+      operationId: buildings_edificis_reactivar_create
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/simulacions/:
+    get:
+      operationId: buildings_edificis_simulacions_retrieve
+      description: |-
+        GET: llista simulacions guardades de l'edifici.
+        POST: calcula i guarda una simulació.
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+    post:
+      operationId: buildings_edificis_simulacions_create
+      description: |-
+        GET: llista simulacions guardades de l'edifici.
+        POST: calcula i guarda una simulació.
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/simulacions/{simulacio_id}/acreditar-implementacio/:
+    post:
+      operationId: buildings_edificis_simulacions_acreditar_implementacio_create
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      - in: path
+        name: simulacio_id
+        schema:
+          type: string
+          pattern: ^\d+$
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/simulacions/{simulacio_id}/sotmetre-votacio/:
+    post:
+      operationId: buildings_edificis_simulacions_sotmetre_votacio_create
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      - in: path
+        name: simulacio_id
+        schema:
+          type: string
+          pattern: ^\d+$
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/simulacions/preview/:
+    post:
+      operationId: buildings_edificis_simulacions_preview_create
+      description: |-
+        Preview de simulació.
+        No guarda res a la base de dades.
+        Pensat perquè Flutter pugui mostrar una comparativa abans/després.
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/votacions-simulacions/:
+    get:
+      operationId: buildings_edificis_votacions_simulacions_retrieve
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/{idEdifici}/votacions-simulacions/{votacio_id}/votar/:
+    post:
+      operationId: buildings_edificis_votacions_simulacions_votar_create
+      parameters:
+      - in: path
+        name: idEdifici
+        schema:
+          type: integer
+        description: A unique integer value identifying this edifici.
+        required: true
+      - in: path
+        name: votacio_id
+        schema:
+          type: string
+          pattern: ^\d+$
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/EdificiDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/cerca/:
+    get:
+      operationId: buildings_edificis_cerca_retrieve
+      description: Endpoint per buscar edificis pel nom del carrer.
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/edificis/manual/:
+    get:
+      operationId: buildings_edificis_manual_retrieve
+      tags:
+      - buildings
+      responses:
+        '200':
+          description: No response body
+  /api/buildings/edificis/manual/{id}/:
+    get:
+      operationId: buildings_edificis_manual_retrieve_2
+      description: |-
+        Mixin per a vistes DRF que necessiten validació ABAC.
+
+        Ús a la vista:
+            class MevaVista(ABACMixin, APIView):
+                def get(self, request, edifici_id):
+                    self.check_edifici_access(request, edifici_id)
+                    ...
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          description: No response body
+  /api/buildings/edificis/mapa/:
+    get:
+      operationId: buildings_edificis_mapa_retrieve
+      description: |-
+        GET /api/buildings/edificis/mapa/
+
+        Retorna els edificis actius amb coordenades vàlides en format GeoJSON.
+
+        Query params opcionals:
+        - scope=public|mine
+        - bbox=minLng,minLat,maxLng,maxLat
+        - tipologia=Residencial
+        - score_min=60
+        - q=text
+        - limit=500
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdificiDetail'
+          description: ''
+  /api/buildings/habitatges/:
+    get:
+      operationId: buildings_habitatges_list
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HabitatgeResum'
+          description: ''
+    post:
+      operationId: buildings_habitatges_create
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HabitatgeDetail'
+          description: ''
+  /api/buildings/habitatges/{referenciaCadastral}/:
+    get:
+      operationId: buildings_habitatges_retrieve
+      parameters:
+      - in: path
+        name: referenciaCadastral
+        schema:
+          type: string
+        description: A unique value identifying this habitatge.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HabitatgeDetail'
+          description: ''
+    put:
+      operationId: buildings_habitatges_update
+      parameters:
+      - in: path
+        name: referenciaCadastral
+        schema:
+          type: string
+        description: A unique value identifying this habitatge.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HabitatgeDetail'
+          description: ''
+    patch:
+      operationId: buildings_habitatges_partial_update
+      parameters:
+      - in: path
+        name: referenciaCadastral
+        schema:
+          type: string
+        description: A unique value identifying this habitatge.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedHabitatgeDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedHabitatgeDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedHabitatgeDetail'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HabitatgeDetail'
+          description: ''
+    delete:
+      operationId: buildings_habitatges_destroy
+      parameters:
+      - in: path
+        name: referenciaCadastral
+        schema:
+          type: string
+        description: A unique value identifying this habitatge.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '204':
+          description: No response body
+  /api/buildings/habitatges/{referenciaCadastral}/solicitar-acces/:
+    post:
+      operationId: buildings_habitatges_solicitar_acces_create
+      parameters:
+      - in: path
+        name: referenciaCadastral
+        schema:
+          type: string
+        description: A unique value identifying this habitatge.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HabitatgeDetail'
+          description: ''
+  /api/buildings/habitatges/{referenciaCadastral}/validar-acces/:
+    post:
+      operationId: buildings_habitatges_validar_acces_create
+      parameters:
+      - in: path
+        name: referenciaCadastral
+        schema:
+          type: string
+        description: A unique value identifying this habitatge.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/HabitatgeDetail'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HabitatgeDetail'
+          description: ''
+  /api/buildings/habitatges/pendents/:
+    get:
+      operationId: buildings_habitatges_pendents_retrieve
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HabitatgeDetail'
+          description: ''
+  /api/buildings/localitzacions/:
+    get:
+      operationId: buildings_localitzacions_list
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Localitzacio'
+          description: ''
+    post:
+      operationId: buildings_localitzacions_create
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Localitzacio'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Localitzacio'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Localitzacio'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Localitzacio'
+          description: ''
+  /api/buildings/localitzacions/{id}/:
+    get:
+      operationId: buildings_localitzacions_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this localitzacio.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Localitzacio'
+          description: ''
+    put:
+      operationId: buildings_localitzacions_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this localitzacio.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Localitzacio'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Localitzacio'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Localitzacio'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Localitzacio'
+          description: ''
+    patch:
+      operationId: buildings_localitzacions_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this localitzacio.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedLocalitzacio'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedLocalitzacio'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedLocalitzacio'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Localitzacio'
+          description: ''
+    delete:
+      operationId: buildings_localitzacions_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this localitzacio.
+        required: true
+      tags:
+      - buildings
+      responses:
+        '204':
+          description: No response body
+  /api/buildings/millores/:
+    get:
+      operationId: buildings_millores_list
+      description: |-
+        Endpoint de catàleg de millores per al frontend.
+        Permet listar i consultar les millores actives disponibles per simular.
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CatalegMillora'
+          description: ''
+  /api/buildings/millores-implementades/{id}/validar/:
+    post:
+      operationId: buildings_millores_implementades_validar_create
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this millora implementada.
+        required: true
+      tags:
+      - buildings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MilloraImplementada'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/MilloraImplementada'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/MilloraImplementada'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MilloraImplementada'
+          description: ''
+  /api/buildings/millores/{id}/:
+    get:
+      operationId: buildings_millores_retrieve
+      description: |-
+        Endpoint de catàleg de millores per al frontend.
+        Permet listar i consultar les millores actives disponibles per simular.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CatalegMillora'
+          description: ''
+  /api/buildings/ranking/:
+    get:
+      operationId: buildings_ranking_list
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRankingList'
+          description: ''
+  /api/buildings/ranking/{id}/:
+    get:
+      operationId: buildings_ranking_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Ranking'
+          description: ''
+  /api/buildings/ranking/{id}/posicion/:
+    get:
+      operationId: buildings_ranking_posicion_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - buildings
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Ranking'
+          description: ''
+  /api/chat/channels/:
+    get:
+      operationId: chat_channels_retrieve
+      description: |-
+        GET: retorna els canals accessibles per l'usuari basant-se únicament
+        en les dades de Django. Cap crida a l'API de GetStream.
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/channels/provision/:
+    post:
+      operationId: chat_channels_provision_create
+      description: |-
+        POST: crea els canals a GetStream si no existeixen i afegeix l'usuari
+        com a membre. Retorna la mateixa llista que GET /channels/ però amb
+        la garantia que els canals ja existeixen a GetStream.
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/messages/{message_id}/:
+    delete:
+      operationId: chat_moderation_messages_destroy
+      description: DELETE /chat/moderation/messages/{message_id}/  — author or ADMIN/superuser.
+      parameters:
+      - in: path
+        name: message_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - chat
+      responses:
+        '204':
+          description: No response body
+  /api/chat/moderation/messages/{message_id}/dismiss-flag/:
+    post:
+      operationId: chat_moderation_messages_dismiss_flag_create
+      description: POST /chat/moderation/messages/{message_id}/dismiss-flag/  — ADMIN/superuser.
+      parameters:
+      - in: path
+        name: message_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/messages/{message_id}/flag/:
+    post:
+      operationId: chat_moderation_messages_flag_create
+      description: POST /chat/moderation/messages/{message_id}/flag/  — any member.
+      parameters:
+      - in: path
+        name: message_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/messages/{message_id}/hide/:
+    post:
+      operationId: chat_moderation_messages_hide_create
+      description: POST /chat/moderation/messages/{message_id}/hide/  — ADMIN/superuser.
+      parameters:
+      - in: path
+        name: message_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/messages/{message_id}/restore/:
+    post:
+      operationId: chat_moderation_messages_restore_create
+      description: POST /chat/moderation/messages/{message_id}/restore/  — ADMIN/superuser.
+      parameters:
+      - in: path
+        name: message_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/users/{user_id}/ban/:
+    post:
+      operationId: chat_moderation_users_ban_create
+      description: POST /chat/moderation/users/{user_id}/ban/  — ADMIN/superuser.
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/users/{user_id}/global-ban/:
+    post:
+      operationId: chat_moderation_users_global_ban_create
+      description: POST /chat/moderation/users/{user_id}/global-ban/  — superuser
+        only.
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/users/{user_id}/global-unban/:
+    post:
+      operationId: chat_moderation_users_global_unban_create
+      description: POST /chat/moderation/users/{user_id}/global-unban/  — superuser
+        only.
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/users/{user_id}/mute/:
+    post:
+      operationId: chat_moderation_users_mute_create
+      description: POST /chat/moderation/users/{user_id}/mute/  — ADMIN/superuser.
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/users/{user_id}/shadow-ban/:
+    post:
+      operationId: chat_moderation_users_shadow_ban_create
+      description: POST /chat/moderation/users/{user_id}/shadow-ban/  — superuser
+        only.
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/users/{user_id}/shadow-unban/:
+    post:
+      operationId: chat_moderation_users_shadow_unban_create
+      description: POST /chat/moderation/users/{user_id}/shadow-unban/  — superuser
+        only.
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/users/{user_id}/unban/:
+    post:
+      operationId: chat_moderation_users_unban_create
+      description: POST /chat/moderation/users/{user_id}/unban/  — ADMIN/superuser.
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/users/{user_id}/unmute/:
+    post:
+      operationId: chat_moderation_users_unmute_create
+      description: POST /chat/moderation/users/{user_id}/unmute/  — ADMIN/superuser.
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/moderation/users/{user_id}/warn/:
+    post:
+      operationId: chat_moderation_users_warn_create
+      description: POST /chat/moderation/users/{user_id}/warn/  — ADMIN/superuser.
+      parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/token/:
+    post:
+      operationId: chat_token_create
+      description: |-
+        Retorna un token de GetStream per a l'usuari autenticat.
+
+        Sincronitza les dades de l'usuari a GetStream abans d'emetre el token.
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/twin-buildings/{edifici_id}/admins/:
+    get:
+      operationId: chat_twin_buildings_admins_retrieve
+      description: |-
+        GET: retorna administradors de finca d'edificis del mateix GrupComparable.
+
+        Només pot consultar-ho l'administrador de finca de l'edifici origen.
+      parameters:
+      - in: path
+        name: edifici_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/chat/twin-buildings/{edifici_id}/channels/:
+    post:
+      operationId: chat_twin_buildings_channels_create
+      description: |-
+        POST: crea o obté un canal directe entre dos administradors de finca
+        d'edificis del mateix GrupComparable.
+      parameters:
+      - in: path
+        name: edifici_id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - chat
+      responses:
+        '200':
+          description: No response body
+  /api/community/votacions/:
+    get:
+      operationId: community_votacions_list
+      tags:
+      - community
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/VotacioList'
+          description: ''
+    post:
+      operationId: community_votacions_create
+      tags:
+      - community
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VotacioCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VotacioCreate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VotacioCreate'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VotacioCreate'
+          description: ''
+  /api/community/votacions/{id}/:
+    get:
+      operationId: community_votacions_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - community
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VotacioDetail'
+          description: ''
+    put:
+      operationId: community_votacions_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - community
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VotacioUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/VotacioUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/VotacioUpdate'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VotacioUpdate'
+          description: ''
+    patch:
+      operationId: community_votacions_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - community
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedVotacioUpdate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedVotacioUpdate'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedVotacioUpdate'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VotacioUpdate'
+          description: ''
+    delete:
+      operationId: community_votacions_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - community
+      responses:
+        '204':
+          description: No response body
+  /api/community/votacions/{id}/resultats/:
+    get:
+      operationId: community_votacions_resultats_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - community
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResultatsVotacio'
+          description: ''
+  /api/community/votacions/{id}/votar/:
+    post:
+      operationId: community_votacions_votar_create
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - community
+      responses:
+        '200':
+          description: No response body
+  /api/leagues/:
+    get:
+      operationId: leagues_list
+      tags:
+      - leagues
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Lliga'
+          description: ''
+    post:
+      operationId: leagues_create
+      tags:
+      - leagues
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Lliga'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Lliga'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Lliga'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lliga'
+          description: ''
+  /api/leagues/{id}/:
+    get:
+      operationId: leagues_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this lliga.
+        required: true
+      tags:
+      - leagues
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lliga'
+          description: ''
+    put:
+      operationId: leagues_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this lliga.
+        required: true
+      tags:
+      - leagues
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Lliga'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Lliga'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Lliga'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lliga'
+          description: ''
+    patch:
+      operationId: leagues_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this lliga.
+        required: true
+      tags:
+      - leagues
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedLliga'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedLliga'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedLliga'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lliga'
+          description: ''
+    delete:
+      operationId: leagues_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this lliga.
+        required: true
+      tags:
+      - leagues
+      responses:
+        '204':
+          description: No response body
+  /api/leagues/{id}/generar_snapshot/:
+    post:
+      operationId: leagues_generar_snapshot_create
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this lliga.
+        required: true
+      tags:
+      - leagues
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Lliga'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Lliga'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Lliga'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lliga'
+          description: ''
+  /api/leagues/{id}/posicio_edifici/:
+    get:
+      operationId: leagues_posicio_edifici_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this lliga.
+        required: true
+      tags:
+      - leagues
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lliga'
+          description: ''
+  /api/leagues/{id}/ranking/:
+    get:
+      operationId: leagues_ranking_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this lliga.
+        required: true
+      tags:
+      - leagues
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lliga'
+          description: ''
+  /api/leagues/evolucio/:
+    get:
+      operationId: leagues_evolucio_retrieve
+      tags:
+      - leagues
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lliga'
+          description: ''
+  /api/notifications/:
+    get:
+      operationId: notifications_list
+      tags:
+      - notifications
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Notificacio'
+          description: ''
+  /api/notifications/{id}/llegir/:
+    post:
+      operationId: notifications_llegir_create
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - notifications
+      responses:
+        '200':
+          description: No response body
+  /api/notifications/llegir-totes/:
+    post:
+      operationId: notifications_llegir_totes_create
+      tags:
+      - notifications
+      responses:
+        '200':
+          description: No response body
+  /api/notifications/no-llegides/:
+    get:
+      operationId: notifications_no_llegides_retrieve
+      tags:
+      - notifications
+      responses:
+        '200':
+          description: No response body
+  /api/participations/:
+    get:
+      operationId: participations_list
+      tags:
+      - participations
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Participacio'
+          description: ''
+    post:
+      operationId: participations_create
+      tags:
+      - participations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Participacio'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Participacio'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Participacio'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Participacio'
+          description: ''
+  /api/participations/{id}/:
+    get:
+      operationId: participations_retrieve
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this participacio.
+        required: true
+      tags:
+      - participations
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Participacio'
+          description: ''
+    put:
+      operationId: participations_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this participacio.
+        required: true
+      tags:
+      - participations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Participacio'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Participacio'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Participacio'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Participacio'
+          description: ''
+    patch:
+      operationId: participations_partial_update
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this participacio.
+        required: true
+      tags:
+      - participations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedParticipacio'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedParticipacio'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedParticipacio'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Participacio'
+          description: ''
+    delete:
+      operationId: participations_destroy
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this participacio.
+        required: true
+      tags:
+      - participations
+      responses:
+        '204':
+          description: No response body
+  /api/participations/{id}/update_score/:
+    post:
+      operationId: participations_update_score_create
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this participacio.
+        required: true
+      tags:
+      - participations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Participacio'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Participacio'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Participacio'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Participacio'
+          description: ''
+  /api/participations/current/:
+    get:
+      operationId: participations_current_retrieve
+      tags:
+      - participations
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Participacio'
+          description: ''
+  /api/participations/evolucio_puntuacio/:
+    get:
+      operationId: participations_evolucio_puntuacio_retrieve
+      tags:
+      - participations
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Participacio'
+          description: ''
+  /api/participations/progres_anual/:
+    get:
+      operationId: participations_progres_anual_retrieve
+      tags:
+      - participations
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Participacio'
+          description: ''
+  /api/schema/:
+    get:
+      operationId: schema_retrieve
+      description: |-
+        OpenApi3 schema for this API. Format can be selected via content negotiation.
+
+        - YAML: application/vnd.oai.openapi
+        - JSON: application/vnd.oai.openapi+json
+      parameters:
+      - in: query
+        name: format
+        schema:
+          type: string
+          enum:
+          - json
+          - yaml
+      - in: query
+        name: lang
+        schema:
+          type: string
+          enum:
+          - af
+          - ar
+          - ar-dz
+          - ast
+          - az
+          - be
+          - bg
+          - bn
+          - br
+          - bs
+          - ca
+          - ckb
+          - cs
+          - cy
+          - da
+          - de
+          - dsb
+          - el
+          - en
+          - en-au
+          - en-gb
+          - eo
+          - es
+          - es-ar
+          - es-co
+          - es-mx
+          - es-ni
+          - es-ve
+          - et
+          - eu
+          - fa
+          - fi
+          - fr
+          - fy
+          - ga
+          - gd
+          - gl
+          - he
+          - hi
+          - hr
+          - hsb
+          - hu
+          - hy
+          - ia
+          - id
+          - ig
+          - io
+          - is
+          - it
+          - ja
+          - ka
+          - kab
+          - kk
+          - km
+          - kn
+          - ko
+          - ky
+          - lb
+          - lt
+          - lv
+          - mk
+          - ml
+          - mn
+          - mr
+          - ms
+          - my
+          - nb
+          - ne
+          - nl
+          - nn
+          - os
+          - pa
+          - pl
+          - pt
+          - pt-br
+          - ro
+          - ru
+          - sk
+          - sl
+          - sq
+          - sr
+          - sr-latn
+          - sv
+          - sw
+          - ta
+          - te
+          - tg
+          - th
+          - tk
+          - tr
+          - tt
+          - udm
+          - ug
+          - uk
+          - ur
+          - uz
+          - vi
+          - zh-hans
+          - zh-hant
+      tags:
+      - schema
+      security:
+      - {}
+      responses:
+        '200':
+          content:
+            application/vnd.oai.openapi:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/yaml:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/vnd.oai.openapi+json:
+              schema:
+                type: object
+                additionalProperties: {}
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+          description: ''
+  /api/seasons/:
+    get:
+      operationId: seasons_list
+      tags:
+      - seasons
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Temporada'
+          description: ''
+    post:
+      operationId: seasons_create
+      tags:
+      - seasons
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+  /api/seasons/{id_temporada}/:
+    get:
+      operationId: seasons_retrieve
+      parameters:
+      - in: path
+        name: id_temporada
+        schema:
+          type: integer
+        description: A unique integer value identifying this temporada.
+        required: true
+      tags:
+      - seasons
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+    put:
+      operationId: seasons_update
+      parameters:
+      - in: path
+        name: id_temporada
+        schema:
+          type: integer
+        description: A unique integer value identifying this temporada.
+        required: true
+      tags:
+      - seasons
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+    patch:
+      operationId: seasons_partial_update
+      parameters:
+      - in: path
+        name: id_temporada
+        schema:
+          type: integer
+        description: A unique integer value identifying this temporada.
+        required: true
+      tags:
+      - seasons
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedTemporada'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedTemporada'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedTemporada'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+    delete:
+      operationId: seasons_destroy
+      parameters:
+      - in: path
+        name: id_temporada
+        schema:
+          type: integer
+        description: A unique integer value identifying this temporada.
+        required: true
+      tags:
+      - seasons
+      responses:
+        '204':
+          description: No response body
+  /api/seasons/{id_temporada}/iniciar/:
+    post:
+      operationId: seasons_iniciar_create
+      parameters:
+      - in: path
+        name: id_temporada
+        schema:
+          type: integer
+        description: A unique integer value identifying this temporada.
+        required: true
+      tags:
+      - seasons
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+  /api/seasons/{id_temporada}/posicio_edifici/:
+    get:
+      operationId: seasons_posicio_edifici_retrieve
+      parameters:
+      - in: path
+        name: id_temporada
+        schema:
+          type: integer
+        description: A unique integer value identifying this temporada.
+        required: true
+      tags:
+      - seasons
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+  /api/seasons/{id_temporada}/ranking/:
+    get:
+      operationId: seasons_ranking_retrieve
+      parameters:
+      - in: path
+        name: id_temporada
+        schema:
+          type: integer
+        description: A unique integer value identifying this temporada.
+        required: true
+      tags:
+      - seasons
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+  /api/seasons/{id_temporada}/ranking/progres/:
+    get:
+      operationId: seasons_ranking_progres_retrieve
+      parameters:
+      - in: path
+        name: id_temporada
+        schema:
+          type: integer
+        description: A unique integer value identifying this temporada.
+        required: true
+      tags:
+      - seasons
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+  /api/seasons/{id_temporada}/tancar/:
+    post:
+      operationId: seasons_tancar_create
+      parameters:
+      - in: path
+        name: id_temporada
+        schema:
+          type: integer
+        description: A unique integer value identifying this temporada.
+        required: true
+      tags:
+      - seasons
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+  /api/seasons/anteriors/:
+    get:
+      operationId: seasons_anteriors_retrieve
+      tags:
+      - seasons
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+  /api/seasons/crear-i-iniciar/:
+    post:
+      operationId: seasons_crear_i_iniciar_create
+      tags:
+      - seasons
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Temporada'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+  /api/seasons/previous/:
+    get:
+      operationId: seasons_previous_retrieve
+      tags:
+      - seasons
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Temporada'
+          description: ''
+  /api/third-party-service/:
+    post:
+      operationId: third_party_service_create
+      description: |-
+        POST /api/third-party/score/
+
+        Body:
+            { "points": [{"lat": 41.38, "lng": 2.17}, ...] }
+
+        Resposta per punt:
+            { "lat": 41.38, "lng": 2.17, "score": 73.4, "match_type": "exacta" }
+            { "lat": 41.38, "lng": 2.17, "score": 42.0, "match_type": "cap" }   # Score random si no trobat
+      tags:
+      - third-party-service
+      responses:
+        '200':
+          description: No response body
+  /api/verification/:
+    get:
+      operationId: verification_list
+      description: |-
+        GET /api/verification/
+        Llista verificacions. AdminSistema veu totes; usuari normal les seves.
+      tags:
+      - verification
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AdminFincaDocumentVerification'
+          description: ''
+  /api/verification/{id}/:
+    get:
+      operationId: verification_retrieve
+      description: |-
+        GET /api/verification/<id>/
+        Detall d'una verificació.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - verification
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminFincaDocumentVerification'
+          description: ''
+  /api/verification/{id}/revisar/:
+    post:
+      operationId: verification_revisar_create
+      description: |-
+        POST /api/verification/<id>/revisar/
+
+        Endpoint exclusiu per a superusuaris.
+        Aprova o rebutja una verificació en estat 'review'.
+
+        Body:
+            {
+                "accio": "aprovar" | "rebutjar",
+                "motiu": "text opcional — requerit si rebutja"
+            }
+
+        Respostes:
+            200 → decisió aplicada correctament
+            400 → accio invàlida o motiu absent en rebuig
+            403 → no és superusuari
+            404 → verificació no trobada
+            409 → verificació no està en estat 'review'
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        required: true
+      tags:
+      - verification
+      responses:
+        '200':
+          description: No response body
+  /api/verification/create/:
+    post:
+      operationId: verification_create_create
+      description: |-
+        POST /api/verification/create/
+        Crea una nova verificació amb un o més documents adjunts.
+      tags:
+      - verification
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AdminFincaDocumentVerificationCreate'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AdminFincaDocumentVerificationCreate'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminFincaDocumentVerificationCreate'
+          description: ''
+components:
+  schemas:
+    AdminFincaDocumentVerification:
+      type: object
+      description: 'Serialitzador de lectura complet: inclou documents i resultat.'
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        user:
+          type: integer
+          readOnly: true
+        user_detail:
+          allOf:
+          - $ref: '#/components/schemas/VerificationUserDetail'
+          readOnly: true
+        edifici:
+          type: integer
+          readOnly: true
+        edifici_detail:
+          allOf:
+          - $ref: '#/components/schemas/VerificationEdificiDetail'
+          readOnly: true
+        status:
+          allOf:
+          - $ref: '#/components/schemas/StatusEnum'
+          readOnly: true
+        celery_task_id:
+          type: string
+          readOnly: true
+        documents:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdminFincaVerificationDocument'
+          readOnly: true
+        result:
+          allOf:
+          - $ref: '#/components/schemas/AdminFincaVerificationResult'
+          readOnly: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_at:
+          type: string
+          format: date-time
+          readOnly: true
+        score:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+        score_flags:
+          readOnly: true
+        suggeriment:
+          type: string
+          readOnly: true
+      required:
+      - celery_task_id
+      - created_at
+      - documents
+      - edifici
+      - edifici_detail
+      - id
+      - result
+      - score
+      - score_flags
+      - status
+      - suggeriment
+      - updated_at
+      - user
+      - user_detail
+    AdminFincaDocumentVerificationCreate:
+      type: object
+      description: |-
+        Escriptura: rep edifici + llistes paral·leles de fitxers i tipus.
+
+        Camp recomanat:
+            edifici              = 1
+            documents_fitxer     = <file1>
+            documents_fitxer     = <file2>
+            documents_doc_type   = identificatiu
+            documents_doc_type   = certificat
+
+        Per compatibilitat temporal també s'accepta:
+            documents_doctype
+      properties:
+        edifici:
+          type: integer
+        documents_fitxer:
+          type: array
+          items:
+            type: string
+            format: uri
+          writeOnly: true
+        documents_doc_type:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocTypeEnum'
+          writeOnly: true
+        documents_doctype:
+          type: array
+          items:
+            $ref: '#/components/schemas/DocTypeEnum'
+          writeOnly: true
+      required:
+      - documents_fitxer
+      - edifici
+    AdminFincaVerificationDocument:
+      type: object
+      description: Lectura d'un document individual.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        fitxer:
+          type: string
+          format: uri
+          readOnly: true
+        doc_type:
+          allOf:
+          - $ref: '#/components/schemas/DocTypeEnum'
+          readOnly: true
+        doc_type_display:
+          type: string
+          readOnly: true
+        ocr_text:
+          type: string
+          readOnly: true
+        extracted_data:
+          readOnly: true
+          nullable: true
+        confidence:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - confidence
+      - created_at
+      - doc_type
+      - doc_type_display
+      - extracted_data
+      - fitxer
+      - id
+      - ocr_text
+    AdminFincaVerificationResult:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        confidence:
+          type: number
+          format: double
+          readOnly: true
+        nom_detectat:
+          type: string
+          readOnly: true
+        dni_detectat:
+          type: string
+          readOnly: true
+        carrec_detectat:
+          type: string
+          readOnly: true
+        comunitat_detectada:
+          type: string
+          readOnly: true
+        vigencia_detectada:
+          type: boolean
+          readOnly: true
+        explicacio:
+          type: string
+          readOnly: true
+        reviewed_by:
+          type: integer
+          readOnly: true
+          nullable: true
+        reviewed_at:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - carrec_detectat
+      - comunitat_detectada
+      - confidence
+      - created_at
+      - dni_detectat
+      - explicacio
+      - id
+      - nom_detectat
+      - reviewed_at
+      - reviewed_by
+      - vigencia_detectada
+    AmbitEnum:
+      enum:
+      - Privat
+      - Comu
+      - Edifici
+      type: string
+      description: |-
+        * `Privat` - Habitatge privat
+        * `Comu` - Element comú
+        * `Edifici` - Edifici complet
+    AuditLog:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        user:
+          type: integer
+          nullable: true
+        user_email:
+          type: string
+          format: email
+          readOnly: true
+        method:
+          type: string
+          maxLength: 10
+        endpoint:
+          type: string
+          maxLength: 500
+        resource_type:
+          type: string
+          maxLength: 100
+        resource_id:
+          type: string
+          maxLength: 100
+        status_code:
+          type: integer
+          maximum: 32767
+          minimum: 0
+        ip_address:
+          type: string
+          nullable: true
+        user_agent:
+          type: string
+          maxLength: 500
+        duration_ms:
+          type: integer
+          maximum: 2147483647
+          minimum: 0
+        timestamp:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - duration_ms
+      - endpoint
+      - id
+      - method
+      - status_code
+      - timestamp
+      - user_email
+    BlankEnum:
+      enum:
+      - ''
+    CatalegMillora:
+      type: object
+      properties:
+        idMillora:
+          type: integer
+          readOnly: true
+        slug:
+          type: string
+          nullable: true
+          description: Identificador estable per seeds, frontend i motor de simulació.
+          maxLength: 120
+          pattern: ^[-a-zA-Z0-9_]+$
+        nom:
+          type: string
+          maxLength: 255
+        descripcio:
+          type: string
+        categoria:
+          $ref: '#/components/schemas/CatalegMilloraCategoriaEnum'
+        activa:
+          type: boolean
+        unitatBase:
+          $ref: '#/components/schemas/UnitatBaseEnum'
+        costEstimatBase:
+          type: number
+          format: double
+          description: Cost orientatiu per unitat base. No és pressupost oficial.
+        costOrientatiuUnitari:
+          type: number
+          format: double
+          readOnly: true
+        mantenimentAnual:
+          type: number
+          format: double
+          description: Cost orientatiu anual de manteniment per unitat base.
+        vidaUtil:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          description: Vida útil orientativa en anys.
+        estalviEnergeticEstimat:
+          type: number
+          format: double
+          description: '% d''estalvi'
+        impactePunts:
+          type: number
+          format: double
+          description: Punts que aporta al rànquing
+        nivellConfianca:
+          $ref: '#/components/schemas/NivellConfiancaEnum'
+        ambit:
+          $ref: '#/components/schemas/AmbitEnum'
+        requereixAcordComunitat:
+          type: boolean
+        tipusAcordEstimat:
+          $ref: '#/components/schemas/TipusAcordEstimatEnum'
+        requereixLlicenciaMunicipal:
+          type: boolean
+        requereixTecnicCompetent:
+          type: boolean
+        requereixCeePrePost:
+          type: boolean
+          description: Certificat Energètic abans i després
+        bloquejadorsFrequents:
+          description: 'Ex: Edifici protegit, façana catalogada.'
+        parametresBase:
+          description: Paràmetres tècnics simplificats que utilitza el motor de simulació.
+      required:
+      - costOrientatiuUnitari
+      - idMillora
+      - nom
+    CatalegMilloraCategoriaEnum:
+      enum:
+      - envolupant
+      - instal_lacio_termica
+      - renovables
+      - electricitat
+      - mobilitat
+      - control_i_monitoratge
+      type: string
+      description: |-
+        * `envolupant` - Envolupant tèrmica
+        * `instal_lacio_termica` - Instal·lació tèrmica
+        * `renovables` - Energies renovables
+        * `electricitat` - Electricitat
+        * `mobilitat` - Mobilitat
+        * `control_i_monitoratge` - Control i monitoratge
+    DadesEnergetiques:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        qualificacioGlobal:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/QualificacioGlobalEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        consumEnergiaPrimaria:
+          type: number
+          format: double
+          maximum: 600.0
+          minimum: 0.0
+        consumEnergiaFinal:
+          type: number
+          format: double
+          maximum: 450.0
+          minimum: 0.0
+        emissionsCO2:
+          type: number
+          format: double
+          maximum: 150.0
+          minimum: 0.0
+        costAnualEnergia:
+          type: number
+          format: double
+          maximum: 15000.0
+          minimum: 0.0
+        energiaCalefaccio:
+          type: number
+          format: double
+          maximum: 250.0
+          minimum: 0.0
+        energiaRefrigeracio:
+          type: number
+          format: double
+          maximum: 120.0
+          minimum: 0.0
+        energiaACS:
+          type: number
+          format: double
+          maximum: 80.0
+          minimum: 0.0
+        energiaEnllumenament:
+          type: number
+          format: double
+          maximum: 50.0
+          minimum: 0.0
+        emissionsCalefaccio:
+          type: number
+          format: double
+          maximum: 100.0
+          minimum: 0.0
+        emissionsRefrigeracio:
+          type: number
+          format: double
+          maximum: 50.0
+          minimum: 0.0
+        emissionsACS:
+          type: number
+          format: double
+          maximum: 40.0
+          minimum: 0.0
+        emissionsEnllumenament:
+          type: number
+          format: double
+          maximum: 25.0
+          minimum: 0.0
+        aillamentTermic:
+          type: number
+          format: double
+          maximum: 5.0
+          minimum: 0.05
+        valorFinestres:
+          type: number
+          format: double
+          maximum: 8.0
+          minimum: 0.5
+        normativa:
+          type: string
+          maxLength: 255
+        einaCertificacio:
+          type: string
+          maxLength: 255
+        motiuCertificacio:
+          type: string
+          maxLength: 255
+        rehabilitacioEnergetica:
+          type: boolean
+        dataEntrada:
+          type: string
+          format: date
+      required:
+      - aillamentTermic
+      - consumEnergiaFinal
+      - consumEnergiaPrimaria
+      - costAnualEnergia
+      - dataEntrada
+      - einaCertificacio
+      - emissionsACS
+      - emissionsCO2
+      - emissionsCalefaccio
+      - emissionsEnllumenament
+      - emissionsRefrigeracio
+      - energiaACS
+      - energiaCalefaccio
+      - energiaEnllumenament
+      - energiaRefrigeracio
+      - id
+      - motiuCertificacio
+      - normativa
+      - valorFinestres
+    DivisioEnum:
+      enum:
+      - Bronze
+      - Silver
+      - Gold
+      type: string
+      description: |-
+        * `Bronze` - Bronze
+        * `Silver` - Silver
+        * `Gold` - Gold
+    DocTypeEnum:
+      enum:
+      - acta_junta
+      - certificat
+      - contracte
+      - cert_col
+      - identificatiu
+      - factura
+      - desconegut
+      type: string
+      description: |-
+        * `acta_junta` - Acta de junta
+        * `certificat` - Certificat de nomenament
+        * `contracte` - Contracte d'administració
+        * `cert_col` - Certificat col·legial
+        * `identificatiu` - Document identificatiu
+        * `factura` - Factura/document comunitat
+        * `desconegut` - Desconegut
+    EdificiDetail:
+      type: object
+      properties:
+        idEdifici:
+          type: integer
+          readOnly: true
+        anyConstruccio:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        tipologia:
+          $ref: '#/components/schemas/TipologiaEnum'
+        superficieTotal:
+          type: number
+          format: double
+        nombrePlantes:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        reglament:
+          type: string
+          maxLength: 100
+        orientacioPrincipal:
+          $ref: '#/components/schemas/OrientacioPrincipalEnum'
+        puntuacioBase:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+        puntuacioBaseOpenData:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+          description: Building Health Score calculat a partir de les dades open data
+            (CEE). Null si no hi ha dades open data associades.
+        classificacioEstimada:
+          type: string
+          readOnly: true
+          nullable: true
+          description: Classificació energètica estimada (A–G). Null si no hi ha dades
+            suficients.
+        classificacioFont:
+          type: string
+          readOnly: true
+          nullable: true
+          description: 'Origen de la classificació: oficial, estimada o insuficient.'
+        font_open_data:
+          type: boolean
+          readOnly: true
+          description: True si les dades bàsiques provenen d'open data CEE
+        num_cas_origen:
+          type: string
+          readOnly: true
+          description: Identificador CEE d'origen
+        tipologia_open_data:
+          allOf:
+          - $ref: '#/components/schemas/TipologiaOpenDataEnum'
+          readOnly: true
+        classificacio_energetica:
+          type: string
+          readOnly: true
+          description: Classificació energètica de l'edifici. Pot ser oficial, estimada
+            o insuficient.
+        heat_risk:
+          type: string
+          readOnly: true
+          description: Heat Risk Index de l'edifici (0–100). Null si manquen dades.
+        actiu:
+          type: boolean
+          readOnly: true
+        dataDesactivacio:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        motivDesactivacio:
+          type: string
+          readOnly: true
+        localitzacio:
+          allOf:
+          - $ref: '#/components/schemas/Localitzacio'
+          readOnly: true
+        localitzacioId:
+          type: integer
+          writeOnly: true
+          nullable: true
+        administradorFinca:
+          type: integer
+          readOnly: true
+          nullable: true
+        grupComparable:
+          type: integer
+          readOnly: true
+          nullable: true
+        habitatges:
+          type: string
+          readOnly: true
+      required:
+      - actiu
+      - administradorFinca
+      - anyConstruccio
+      - classificacioEstimada
+      - classificacioFont
+      - classificacio_energetica
+      - dataDesactivacio
+      - font_open_data
+      - grupComparable
+      - habitatges
+      - heat_risk
+      - idEdifici
+      - localitzacio
+      - motivDesactivacio
+      - num_cas_origen
+      - orientacioPrincipal
+      - puntuacioBase
+      - puntuacioBaseOpenData
+      - reglament
+      - superficieTotal
+      - tipologia
+      - tipologia_open_data
+    EdificiList:
+      type: object
+      properties:
+        idEdifici:
+          type: integer
+          readOnly: true
+        localitzacio:
+          type: integer
+          nullable: true
+        tipologia:
+          $ref: '#/components/schemas/TipologiaEnum'
+        anyConstruccio:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        superficieTotal:
+          type: number
+          format: double
+        puntuacioBase:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+      required:
+      - anyConstruccio
+      - idEdifici
+      - puntuacioBase
+      - superficieTotal
+      - tipologia
+    Estat002Enum:
+      enum:
+      - oberta
+      - tancada
+      - cancel·lada
+      type: string
+      description: |-
+        * `oberta` - Oberta
+        * `tancada` - Tancada
+        * `cancel·lada` - Cancel·lada
+    EstatValidacioEnum:
+      enum:
+      - PendentDocumentacio
+      - EnRevisió
+      - Validada
+      - Rebutjada
+      type: string
+      description: |-
+        * `PendentDocumentacio` - Pendent de documentació
+        * `EnRevisió` - En revisió
+        * `Validada` - Validada
+        * `Rebutjada` - Rebutjada
+    HabitatgeDetail:
+      type: object
+      properties:
+        referenciaCadastral:
+          type: string
+          maxLength: 50
+        dadesEnergetiques:
+          allOf:
+          - $ref: '#/components/schemas/DadesEnergetiques'
+          readOnly: true
+        solicitant:
+          allOf:
+          - $ref: '#/components/schemas/UsuariBasic'
+          readOnly: true
+        propietari:
+          allOf:
+          - $ref: '#/components/schemas/UsuariBasic'
+          readOnly: true
+        llogater:
+          allOf:
+          - $ref: '#/components/schemas/UsuariBasic'
+          readOnly: true
+        rolSolicitat:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/RolSolicitatEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        planta:
+          type: string
+          maxLength: 10
+        porta:
+          type: string
+          maxLength: 10
+        superficie:
+          type: number
+          format: double
+        anyReforma:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        estatValidacio:
+          allOf:
+          - $ref: '#/components/schemas/EstatValidacioEnum'
+          readOnly: true
+        edifici:
+          type: integer
+        usuari:
+          type: integer
+          readOnly: true
+          nullable: true
+      required:
+      - dadesEnergetiques
+      - edifici
+      - estatValidacio
+      - llogater
+      - planta
+      - porta
+      - propietari
+      - referenciaCadastral
+      - solicitant
+      - superficie
+      - usuari
+    HabitatgeResum:
+      type: object
+      properties:
+        referenciaCadastral:
+          type: string
+          maxLength: 50
+        planta:
+          type: string
+          maxLength: 10
+        porta:
+          type: string
+          maxLength: 10
+        superficie:
+          type: number
+          format: double
+        anyReforma:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+      required:
+      - planta
+      - porta
+      - referenciaCadastral
+      - superficie
+    Lliga:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        nom:
+          type: string
+          maxLength: 100
+        categoria:
+          $ref: '#/components/schemas/LligaCategoriaEnum'
+        divisio:
+          $ref: '#/components/schemas/DivisioEnum'
+        temporada:
+          type: integer
+      required:
+      - categoria
+      - divisio
+      - id
+      - nom
+      - temporada
+    LligaCategoriaEnum:
+      enum:
+      - EFICIENCIA
+      - RESILIENCIA
+      - PROGRES
+      type: string
+      description: |-
+        * `EFICIENCIA` - Eficiencia
+        * `RESILIENCIA` - Resiliencia
+        * `PROGRES` - Progres
+    Localitzacio:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        carrer:
+          type: string
+          maxLength: 255
+        numero:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        codiPostal:
+          type: string
+          maxLength: 10
+        barri:
+          type: string
+          maxLength: 100
+        latitud:
+          type: number
+          format: double
+          nullable: true
+        longitud:
+          type: number
+          format: double
+          nullable: true
+        zonaClimatica:
+          type: string
+          nullable: true
+          maxLength: 10
+      required:
+      - barri
+      - carrer
+      - codiPostal
+      - id
+      - numero
+    MilloraImplementada:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        millora:
+          allOf:
+          - $ref: '#/components/schemas/CatalegMillora'
+          readOnly: true
+        dataExecucio:
+          type: string
+          format: date
+        costReal:
+          type: number
+          format: double
+        estatValidacio:
+          $ref: '#/components/schemas/EstatValidacioEnum'
+        observacionsAdmin:
+          type: string
+          description: Motiu del rebutj o indicacions
+        documentacioAdjunta:
+          type: string
+          format: uri
+          nullable: true
+      required:
+      - costReal
+      - dataExecucio
+      - id
+      - millora
+    NivellConfiancaEnum:
+      enum:
+      - Baix
+      - Mig
+      - Alt
+      type: string
+      description: |-
+        * `Baix` - Baix
+        * `Mig` - Mig
+        * `Alt` - Alt
+    Notificacio:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        tipus:
+          allOf:
+          - $ref: '#/components/schemas/TipusEnum'
+          readOnly: true
+        titol:
+          type: string
+          readOnly: true
+        cos:
+          type: string
+          readOnly: true
+        llegida:
+          type: boolean
+          readOnly: true
+        dataCreacio:
+          type: string
+          format: date-time
+          readOnly: true
+        objecte_id:
+          type: integer
+          readOnly: true
+          nullable: true
+      required:
+      - cos
+      - dataCreacio
+      - id
+      - llegida
+      - objecte_id
+      - tipus
+      - titol
+    NullEnum:
+      enum:
+      - null
+    OpcioVot:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        text:
+          type: string
+          maxLength: 200
+        ordre:
+          type: integer
+          maximum: 32767
+          minimum: 0
+        num_vots:
+          type: string
+          readOnly: true
+      required:
+      - id
+      - num_vots
+      - text
+    OrientacioPrincipalEnum:
+      enum:
+      - Nord
+      - Sud
+      - Est
+      - Oest
+      type: string
+      description: |-
+        * `Nord` - Nord
+        * `Sud` - Sud
+        * `Est` - Est
+        * `Oest` - Oest
+    PaginatedAuditLogList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditLog'
+    PaginatedRankingList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Ranking'
+    Participacio:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        puntuacio_inicial:
+          type: number
+          format: double
+        puntuacio:
+          type: number
+          format: double
+        posicio:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        divisio:
+          type: string
+          maxLength: 50
+        edifici:
+          type: integer
+        lliga:
+          type: integer
+      required:
+      - divisio
+      - edifici
+      - id
+      - lliga
+      - posicio
+      - puntuacio
+      - puntuacio_inicial
+    PatchedDadesEnergetiques:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        qualificacioGlobal:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/QualificacioGlobalEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        consumEnergiaPrimaria:
+          type: number
+          format: double
+          maximum: 600.0
+          minimum: 0.0
+        consumEnergiaFinal:
+          type: number
+          format: double
+          maximum: 450.0
+          minimum: 0.0
+        emissionsCO2:
+          type: number
+          format: double
+          maximum: 150.0
+          minimum: 0.0
+        costAnualEnergia:
+          type: number
+          format: double
+          maximum: 15000.0
+          minimum: 0.0
+        energiaCalefaccio:
+          type: number
+          format: double
+          maximum: 250.0
+          minimum: 0.0
+        energiaRefrigeracio:
+          type: number
+          format: double
+          maximum: 120.0
+          minimum: 0.0
+        energiaACS:
+          type: number
+          format: double
+          maximum: 80.0
+          minimum: 0.0
+        energiaEnllumenament:
+          type: number
+          format: double
+          maximum: 50.0
+          minimum: 0.0
+        emissionsCalefaccio:
+          type: number
+          format: double
+          maximum: 100.0
+          minimum: 0.0
+        emissionsRefrigeracio:
+          type: number
+          format: double
+          maximum: 50.0
+          minimum: 0.0
+        emissionsACS:
+          type: number
+          format: double
+          maximum: 40.0
+          minimum: 0.0
+        emissionsEnllumenament:
+          type: number
+          format: double
+          maximum: 25.0
+          minimum: 0.0
+        aillamentTermic:
+          type: number
+          format: double
+          maximum: 5.0
+          minimum: 0.05
+        valorFinestres:
+          type: number
+          format: double
+          maximum: 8.0
+          minimum: 0.5
+        normativa:
+          type: string
+          maxLength: 255
+        einaCertificacio:
+          type: string
+          maxLength: 255
+        motiuCertificacio:
+          type: string
+          maxLength: 255
+        rehabilitacioEnergetica:
+          type: boolean
+        dataEntrada:
+          type: string
+          format: date
+    PatchedEdificiDetail:
+      type: object
+      properties:
+        idEdifici:
+          type: integer
+          readOnly: true
+        anyConstruccio:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        tipologia:
+          $ref: '#/components/schemas/TipologiaEnum'
+        superficieTotal:
+          type: number
+          format: double
+        nombrePlantes:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        reglament:
+          type: string
+          maxLength: 100
+        orientacioPrincipal:
+          $ref: '#/components/schemas/OrientacioPrincipalEnum'
+        puntuacioBase:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+        puntuacioBaseOpenData:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+          description: Building Health Score calculat a partir de les dades open data
+            (CEE). Null si no hi ha dades open data associades.
+        classificacioEstimada:
+          type: string
+          readOnly: true
+          nullable: true
+          description: Classificació energètica estimada (A–G). Null si no hi ha dades
+            suficients.
+        classificacioFont:
+          type: string
+          readOnly: true
+          nullable: true
+          description: 'Origen de la classificació: oficial, estimada o insuficient.'
+        font_open_data:
+          type: boolean
+          readOnly: true
+          description: True si les dades bàsiques provenen d'open data CEE
+        num_cas_origen:
+          type: string
+          readOnly: true
+          description: Identificador CEE d'origen
+        tipologia_open_data:
+          allOf:
+          - $ref: '#/components/schemas/TipologiaOpenDataEnum'
+          readOnly: true
+        classificacio_energetica:
+          type: string
+          readOnly: true
+          description: Classificació energètica de l'edifici. Pot ser oficial, estimada
+            o insuficient.
+        heat_risk:
+          type: string
+          readOnly: true
+          description: Heat Risk Index de l'edifici (0–100). Null si manquen dades.
+        actiu:
+          type: boolean
+          readOnly: true
+        dataDesactivacio:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        motivDesactivacio:
+          type: string
+          readOnly: true
+        localitzacio:
+          allOf:
+          - $ref: '#/components/schemas/Localitzacio'
+          readOnly: true
+        localitzacioId:
+          type: integer
+          writeOnly: true
+          nullable: true
+        administradorFinca:
+          type: integer
+          readOnly: true
+          nullable: true
+        grupComparable:
+          type: integer
+          readOnly: true
+          nullable: true
+        habitatges:
+          type: string
+          readOnly: true
+    PatchedHabitatgeDetail:
+      type: object
+      properties:
+        referenciaCadastral:
+          type: string
+          maxLength: 50
+        dadesEnergetiques:
+          allOf:
+          - $ref: '#/components/schemas/DadesEnergetiques'
+          readOnly: true
+        solicitant:
+          allOf:
+          - $ref: '#/components/schemas/UsuariBasic'
+          readOnly: true
+        propietari:
+          allOf:
+          - $ref: '#/components/schemas/UsuariBasic'
+          readOnly: true
+        llogater:
+          allOf:
+          - $ref: '#/components/schemas/UsuariBasic'
+          readOnly: true
+        rolSolicitat:
+          nullable: true
+          oneOf:
+          - $ref: '#/components/schemas/RolSolicitatEnum'
+          - $ref: '#/components/schemas/NullEnum'
+        planta:
+          type: string
+          maxLength: 10
+        porta:
+          type: string
+          maxLength: 10
+        superficie:
+          type: number
+          format: double
+        anyReforma:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+        estatValidacio:
+          allOf:
+          - $ref: '#/components/schemas/EstatValidacioEnum'
+          readOnly: true
+        edifici:
+          type: integer
+        usuari:
+          type: integer
+          readOnly: true
+          nullable: true
+    PatchedLliga:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        nom:
+          type: string
+          maxLength: 100
+        categoria:
+          $ref: '#/components/schemas/LligaCategoriaEnum'
+        divisio:
+          $ref: '#/components/schemas/DivisioEnum'
+        temporada:
+          type: integer
+    PatchedLocalitzacio:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        carrer:
+          type: string
+          maxLength: 255
+        numero:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        codiPostal:
+          type: string
+          maxLength: 10
+        barri:
+          type: string
+          maxLength: 100
+        latitud:
+          type: number
+          format: double
+          nullable: true
+        longitud:
+          type: number
+          format: double
+          nullable: true
+        zonaClimatica:
+          type: string
+          nullable: true
+          maxLength: 10
+    PatchedParticipacio:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        puntuacio_inicial:
+          type: number
+          format: double
+        puntuacio:
+          type: number
+          format: double
+        posicio:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        divisio:
+          type: string
+          maxLength: 50
+        edifici:
+          type: integer
+        lliga:
+          type: integer
+    PatchedTemporada:
+      type: object
+      properties:
+        id_temporada:
+          type: integer
+          readOnly: true
+        nom:
+          type: string
+          maxLength: 100
+        dataInici:
+          type: string
+          format: date
+        dataFi:
+          type: string
+          format: date
+        estat:
+          allOf:
+          - $ref: '#/components/schemas/TemporadaEstatEnum'
+          readOnly: true
+        activa:
+          type: boolean
+          readOnly: true
+    PatchedVotacioUpdate:
+      type: object
+      properties:
+        titol:
+          type: string
+          maxLength: 200
+        descripcio:
+          type: string
+        dataLimit:
+          type: string
+          format: date-time
+          nullable: true
+        estat:
+          $ref: '#/components/schemas/Estat002Enum'
+    QualificacioGlobalEnum:
+      enum:
+      - A
+      - B
+      - C
+      - D
+      - E
+      - F
+      - G
+      type: string
+      description: |-
+        * `A` - A
+        * `B` - B
+        * `C` - C
+        * `D` - D
+        * `E` - E
+        * `F` - F
+        * `G` - G
+    Ranking:
+      type: object
+      properties:
+        idEdifici:
+          type: integer
+          readOnly: true
+        puntuacioBase:
+          type: number
+          format: double
+          readOnly: true
+          nullable: true
+      required:
+      - idEdifici
+      - puntuacioBase
+    Register:
+      type: object
+      properties:
+        email:
+          type: string
+          format: email
+          maxLength: 254
+        first_name:
+          type: string
+          maxLength: 150
+        last_name:
+          type: string
+          maxLength: 150
+        password:
+          type: string
+          writeOnly: true
+          minLength: 8
+        password_confirm:
+          type: string
+          writeOnly: true
+        role:
+          $ref: '#/components/schemas/RoleEnum'
+      required:
+      - email
+      - password
+      - password_confirm
+    ResultatsVotacio:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        titol:
+          type: string
+          maxLength: 200
+        estat:
+          $ref: '#/components/schemas/Estat002Enum'
+        dataLimit:
+          type: string
+          format: date-time
+          nullable: true
+        num_vots_total:
+          type: string
+          readOnly: true
+        opcions:
+          type: string
+          readOnly: true
+      required:
+      - id
+      - num_vots_total
+      - opcions
+      - titol
+    RolSolicitatEnum:
+      enum:
+      - owner
+      - tenant
+      type: string
+      description: |-
+        * `owner` - Propietari
+        * `tenant` - Llogater
+    RoleEnum:
+      enum:
+      - admin
+      - owner
+      - tenant
+      type: string
+      description: |-
+        * `admin` - Administrador
+        * `owner` - Propietari
+        * `tenant` - Llogater
+    StatusEnum:
+      enum:
+      - pending
+      - running
+      - approved
+      - rejected
+      - review
+      type: string
+      description: |-
+        * `pending` - Pendent
+        * `running` - Processant
+        * `approved` - Aprovada
+        * `rejected` - Rebutjada
+        * `review` - Revisió manual
+    Temporada:
+      type: object
+      properties:
+        id_temporada:
+          type: integer
+          readOnly: true
+        nom:
+          type: string
+          maxLength: 100
+        dataInici:
+          type: string
+          format: date
+        dataFi:
+          type: string
+          format: date
+        estat:
+          allOf:
+          - $ref: '#/components/schemas/TemporadaEstatEnum'
+          readOnly: true
+        activa:
+          type: boolean
+          readOnly: true
+      required:
+      - activa
+      - dataFi
+      - dataInici
+      - estat
+      - id_temporada
+      - nom
+    TemporadaEstatEnum:
+      enum:
+      - PENDENT
+      - ACTIVA
+      - TANCADA
+      type: string
+      description: |-
+        * `PENDENT` - Pendent
+        * `ACTIVA` - Activa
+        * `TANCADA` - Tancada
+    TipologiaEnum:
+      enum:
+      - Residencial
+      - Comercial
+      - Sanitari
+      - Educatiu
+      - Mixt
+      type: string
+      description: |-
+        * `Residencial` - Residencial
+        * `Comercial` - Comercial
+        * `Sanitari` - Sanitari
+        * `Educatiu` - Educatiu
+        * `Mixt` - Mixt
+    TipologiaOpenDataEnum:
+      enum:
+      - BlocPisos
+      - Unifamiliar
+      - HabitatgeBloc
+      - Terciari
+      - Desconegut
+      type: string
+      description: |-
+        * `BlocPisos` - Bloc de pisos
+        * `Unifamiliar` - Casa unifamiliar
+        * `HabitatgeBloc` - Habitatge individual en bloc
+        * `Terciari` - Terciari
+        * `Desconegut` - Desconegut
+    TipusAcordEstimatEnum:
+      enum:
+      - No cal
+      - MajoriaSimple
+      - Majoria35
+      - Unanimitat
+      type: string
+      description: |-
+        * `No cal` - No sol requerir acord
+        * `MajoriaSimple` - Majoria simple
+        * `Majoria35` - Majoria de 3/5
+        * `Unanimitat` - Unanimitat
+    TipusEnum:
+      enum:
+      - nova_votacio
+      - votacio_tancada
+      - votacio_cancellada
+      type: string
+      description: |-
+        * `nova_votacio` - Nova votació
+        * `votacio_tancada` - Votació tancada
+        * `votacio_cancellada` - Votació cancel·lada
+    TokenRefresh:
+      type: object
+      properties:
+        access:
+          type: string
+          readOnly: true
+        refresh:
+          type: string
+      required:
+      - access
+      - refresh
+    UnitatBaseEnum:
+      enum:
+      - m2
+      - unitat
+      - kwp
+      - kwh
+      - habitatge
+      - edifici
+      type: string
+      description: |-
+        * `m2` - m²
+        * `unitat` - Unitat
+        * `kwp` - kWp
+        * `kwh` - kWh
+        * `habitatge` - Habitatge
+        * `edifici` - Edifici
+    UserAdmin:
+      type: object
+      description: Representació completa d'un usuari per al panell d'administració.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        email:
+          type: string
+          format: email
+          maxLength: 254
+        first_name:
+          type: string
+          maxLength: 150
+        last_name:
+          type: string
+          maxLength: 150
+        is_active:
+          type: boolean
+          title: Active
+          description: Designates whether this user should be treated as active. Unselect
+            this instead of deleting accounts.
+        is_superuser:
+          type: boolean
+          title: Superuser status
+          description: Designates that this user has all permissions without explicitly
+            assigning them.
+        date_joined:
+          type: string
+          format: date-time
+        role:
+          type: string
+          readOnly: true
+        account_status:
+          type: string
+          readOnly: true
+        suspension_reason:
+          type: string
+          readOnly: true
+        suspended_until:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - account_status
+      - email
+      - id
+      - role
+      - suspended_until
+      - suspension_reason
+    UsuariBasic:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        first_name:
+          type: string
+          maxLength: 150
+        last_name:
+          type: string
+          maxLength: 150
+        email:
+          type: string
+          format: email
+          maxLength: 254
+      required:
+      - email
+      - id
+    VerificationEdificiDetail:
+      type: object
+      properties:
+        idEdifici:
+          type: integer
+          readOnly: true
+        localitzacio:
+          type: string
+          readOnly: true
+        adreca:
+          type: string
+          readOnly: true
+      required:
+      - adreca
+      - idEdifici
+      - localitzacio
+    VerificationUserDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        first_name:
+          type: string
+          readOnly: true
+        last_name:
+          type: string
+          readOnly: true
+        email:
+          type: string
+          format: email
+          readOnly: true
+      required:
+      - email
+      - first_name
+      - id
+      - last_name
+    VotacioCreate:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        edifici:
+          type: integer
+        titol:
+          type: string
+          maxLength: 200
+        descripcio:
+          type: string
+        dataLimit:
+          type: string
+          format: date-time
+          nullable: true
+        opcions:
+          type: array
+          items:
+            type: string
+            maxLength: 200
+          writeOnly: true
+          minItems: 2
+      required:
+      - edifici
+      - id
+      - opcions
+      - titol
+    VotacioDetail:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        edifici:
+          type: integer
+        titol:
+          type: string
+          maxLength: 200
+        descripcio:
+          type: string
+        estat:
+          $ref: '#/components/schemas/Estat002Enum'
+        dataCreacio:
+          type: string
+          format: date-time
+          readOnly: true
+        dataLimit:
+          type: string
+          format: date-time
+          nullable: true
+        opcions:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpcioVot'
+          readOnly: true
+        num_vots_total:
+          type: string
+          readOnly: true
+        ha_votat:
+          type: string
+          readOnly: true
+      required:
+      - dataCreacio
+      - edifici
+      - ha_votat
+      - id
+      - num_vots_total
+      - opcions
+      - titol
+    VotacioList:
+      type: object
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        titol:
+          type: string
+          maxLength: 200
+        estat:
+          $ref: '#/components/schemas/Estat002Enum'
+        dataCreacio:
+          type: string
+          format: date-time
+          readOnly: true
+        dataLimit:
+          type: string
+          format: date-time
+          nullable: true
+        num_vots_total:
+          type: string
+          readOnly: true
+      required:
+      - dataCreacio
+      - id
+      - num_vots_total
+      - titol
+    VotacioUpdate:
+      type: object
+      properties:
+        titol:
+          type: string
+          maxLength: 200
+        descripcio:
+          type: string
+        dataLimit:
+          type: string
+          format: date-time
+          nullable: true
+        estat:
+          $ref: '#/components/schemas/Estat002Enum'

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -32,3 +32,4 @@ django-celery-results==2.5.1
 # Coverage for testing
 coverage==7.14.0
 
+drf-spectacular


### PR DESCRIPTION
## Resum

Aquesta PR afegeix suport OpenAPI/Swagger al backend utilitzant `drf-spectacular`.

### Afegit

* Endpoint Swagger UI: `/api/swagger/`
* Endpoint esquema OpenAPI: `/api/schema/`
* Generació automàtica de l’esquema a:

  * `backend/docs/api/api.yml`

### Canvis tècnics

* Afegida la dependència `drf-spectacular`
* Configurat `DEFAULT_SCHEMA_CLASS`
* Registrades les rutes Swagger i schema a `config/urls.py`

### Validació

* `python manage.py check` ✅
* Swagger UI accessible a:

  * `http://localhost/api/swagger/`
* Esquema OpenAPI generat correctament ✅

### Notes

La generació de l’esquema mostra warnings/errors degut a diversos `APIView` custom i a l’autenticació pròpia (`AccountStatusJWTAuthentication`). Això no afecta el funcionament del backend ni la disponibilitat de Swagger.
