### PR TITLE
fix: connecta dashboard admin i limita temporades a edificis gestionats

### DIFF
--- a/backend/apps/accounts/tests.py
+++ b/backend/apps/accounts/tests.py
@@ -1959,3 +1959,94 @@ class PendingAdminVerificationAccessTests(BaseTestData):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+
+@override_settings(REST_FRAMEWORK=NO_THROTTLE_REST_FRAMEWORK)
+class AdminDashboardSummaryTests(APITestCase):
+    def setUp(self):
+        cache.clear()
+        self.admin = User.objects.create_superuser(
+            email="dashboard-admin@example.com",
+            password="Adminpass123",
+        )
+        self.user = User.objects.create_user(
+            email="dashboard-user@example.com",
+            password="Password123",
+        )
+
+    def test_system_admin_can_read_dashboard_summary(self):
+        from apps.buildings.models import (
+            CatalegMillora,
+            Edifici,
+            EstatValidacio,
+            GrupComparable,
+            Localitzacio,
+            MilloraImplementada,
+        )
+        from apps.verification.models import AdminFincaDocumentVerification
+        from apps.seasons.models import Temporada, EstatTemporada
+
+        grup = GrupComparable.objects.create(
+            idGrup=9091,
+            zonaClimatica="C2",
+            tipologia="Residencial",
+            rangSuperficie="100-200",
+        )
+        localitzacio = Localitzacio.objects.create(
+            carrer="Carrer Dashboard",
+            numero=1,
+            codiPostal="08001",
+            barri="Eixample",
+        )
+        edifici = Edifici.objects.create(
+            anyConstruccio=2000,
+            tipologia="Residencial",
+            superficieTotal=100,
+            reglament="CTE",
+            orientacioPrincipal="Sud",
+            localitzacio=localitzacio,
+            grupComparable=grup,
+            administradorFinca=self.user,
+        )
+        millora = CatalegMillora.objects.create(
+            nom="Millora Dashboard",
+            descripcio="Test",
+            impactePunts=5,
+            activa=True,
+        )
+        MilloraImplementada.objects.create(
+            millora=millora,
+            edifici=edifici,
+            dataExecucio="2026-01-01",
+            costReal=1000,
+            estatValidacio=EstatValidacio.EN_REVISIO,
+        )
+        AdminFincaDocumentVerification.objects.create(
+            user=self.user,
+            edifici=edifici,
+            status=AdminFincaDocumentVerification.Status.PENDING,
+        )
+        Temporada.objects.create(
+            nom="Temporada Dashboard",
+            dataInici="2026-01-01",
+            dataFi="2026-12-31",
+            estat=EstatTemporada.ACTIVA,
+        )
+
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(reverse("admin-dashboard-summary"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertGreaterEqual(response.data["users_total"], 2)
+        self.assertEqual(response.data["buildings_managed"], 1)
+        self.assertEqual(response.data["pending_improvements"], 1)
+        self.assertEqual(response.data["pending_admin_verifications"], 1)
+        self.assertIsNotNone(response.data["active_season"])
+
+    def test_non_system_admin_cannot_read_dashboard_summary(self):
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get(reverse("admin-dashboard-summary"))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/apps/accounts/urls.py
+++ b/backend/apps/accounts/urls.py
@@ -9,6 +9,7 @@ from apps.accounts.views import (
     UserListView, UserDetailView,
     UserBlockView, UserUnblockView,
     UserSuspendView, UserUnsuspendView,
+    AdminDashboardSummaryView,
 )
 
 urlpatterns = [
@@ -33,6 +34,7 @@ urlpatterns = [
 
     # Consulta: edificis accessibles per l'usuari autenticat
     path("me/edificis/", MeEdificisView.as_view(), name="me-edificis"),
+    path("admin/dashboard-summary/", AdminDashboardSummaryView.as_view(), name="admin-dashboard-summary"),
 
     # Assignació: resident → habitatge (AdminFinca, ABAC-B)
     path(

--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -422,3 +422,74 @@ class UserUnsuspendView(APIView):
         profile.save(update_fields=["account_status", "suspension_reason", "suspended_until", "updated_at"])
 
         return Response(UserAdminSerializer(user).data, status=status.HTTP_200_OK)
+
+
+class AdminDashboardSummaryView(APIView):
+    """Mètriques agregades per al panell d'administració del sistema."""
+    permission_classes = [IsAdminSistema]
+
+    def get(self, request):
+        from apps.buildings.models import (
+            Edifici,
+            Habitatge,
+            MilloraImplementada,
+            EstatValidacio,
+        )
+        from apps.verification.models import AdminFincaDocumentVerification
+        from apps.seasons.models import Temporada, EstatTemporada
+
+        temporada_activa = (
+            Temporada.objects
+            .filter(estat=EstatTemporada.ACTIVA)
+            .order_by("-dataInici", "-id_temporada")
+            .first()
+        )
+
+        pending_improvements = MilloraImplementada.objects.filter(
+            estatValidacio__in=[
+                EstatValidacio.PENDENT_DOCUMENTACIO,
+                EstatValidacio.EN_REVISIO,
+            ]
+        ).count()
+
+        pending_admin_verifications = AdminFincaDocumentVerification.objects.filter(
+            status__in=[
+                AdminFincaDocumentVerification.Status.PENDING,
+                AdminFincaDocumentVerification.Status.RUNNING,
+                AdminFincaDocumentVerification.Status.REVIEW,
+            ]
+        ).count()
+
+        pending_housing_requests = Habitatge.objects.filter(
+            estatValidacio__in=[
+                EstatValidacio.PENDENT_DOCUMENTACIO,
+                EstatValidacio.EN_REVISIO,
+            ],
+            solicitant__isnull=False,
+        ).count()
+
+        active_season = None
+        if temporada_activa:
+            active_season = {
+                "id": temporada_activa.id_temporada,
+                "nom": temporada_activa.nom,
+                "dataInici": temporada_activa.dataInici,
+                "dataFi": temporada_activa.dataFi,
+                "estat": temporada_activa.estat,
+            }
+
+        return Response(
+            {
+                "users_total": User.objects.count(),
+                "buildings_total": Edifici.actius.count(),
+                "buildings_managed": Edifici.actius.filter(
+                    administradorFinca__isnull=False
+                ).count(),
+                "pending_improvements": pending_improvements,
+                "pending_admin_verifications": pending_admin_verifications,
+                "pending_housing_requests": pending_housing_requests,
+                "active_season": active_season,
+            },
+            status=status.HTTP_200_OK,
+        )
+

--- a/backend/apps/buildings/serializers.py
+++ b/backend/apps/buildings/serializers.py
@@ -727,18 +727,35 @@ class SimulacioMilloraSerializer(serializers.ModelSerializer):
 
 class MilloraImplementadaSerializer(serializers.ModelSerializer):
     millora = CatalegMilloraSerializer(read_only=True)
+    edifici_id = serializers.IntegerField(source="edifici.idEdifici", read_only=True)
+    edifici_adreca = serializers.SerializerMethodField()
+    simulacio_id = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = MilloraImplementada
         fields = [
             "id",
             "millora",
+            "edifici_id",
+            "edifici_adreca",
+            "simulacio_id",
             "dataExecucio",
             "costReal",
             "estatValidacio",
             "observacionsAdmin",
             "documentacioAdjunta",
         ]
+
+    def get_edifici_adreca(self, obj):
+        localitzacio = getattr(obj.edifici, "localitzacio", None)
+        if not localitzacio:
+            return f"Edifici {obj.edifici_id}"
+
+        carrer = getattr(localitzacio, "carrer", "") or ""
+        numero = getattr(localitzacio, "numero", "") or ""
+
+        adreca = f"{carrer}, {numero}".strip(", ")
+        return adreca or f"Edifici {obj.edifici_id}"
 
 
 class ValidacioMilloraSerializer(serializers.Serializer):

--- a/backend/apps/buildings/views.py
+++ b/backend/apps/buildings/views.py
@@ -1051,9 +1051,40 @@ class EdificiViewSet(viewsets.ModelViewSet):
 
 
 class MilloraImplementadaViewSet(viewsets.GenericViewSet):
-    queryset = MilloraImplementada.objects.select_related("millora", "edifici", "simulacio")
+    queryset = MilloraImplementada.objects.select_related(
+        "millora",
+        "edifici",
+        "edifici__localitzacio",
+        "simulacio",
+    )
     serializer_class = MilloraImplementadaSerializer
     permission_classes = [IsAuthenticated, EsAdminMilloraImplementada]
+
+    def get_queryset(self):
+        queryset = super().get_queryset().order_by("-dataExecucio", "-id")
+
+        estat = self.request.query_params.get("estat")
+        if estat:
+            queryset = queryset.filter(estatValidacio=estat)
+
+        return queryset
+
+    def list(self, request, *args, **kwargs):
+        """Llista millores implementades per al panell d'administració."""
+        serializer = self.get_serializer(self.get_queryset(), many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=["get"], url_path="pendents")
+    def pendents(self, request):
+        """Llista millores pendents de revisió/validació final."""
+        queryset = self.get_queryset().filter(
+            estatValidacio__in=[
+                EstatValidacio.PENDENT_DOCUMENTACIO,
+                EstatValidacio.EN_REVISIO,
+            ]
+        )
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=["post"], url_path="validar")
     def validar(self, request, pk=None):

--- a/backend/apps/seasons/services.py
+++ b/backend/apps/seasons/services.py
@@ -130,7 +130,14 @@ def actualitzar_puntuacions_base_inici_temporada(temporada: Temporada) -> Dict[s
     }
 
     with transaction.atomic():
-        edificis = Edifici.actius.select_for_update().all()
+        # Només processem edificis gestionats dins l'app.
+        # Això evita recalcular puntuació i crear historial BHS per milers
+        # d'edificis Open Data/CEE sense administrador assignat.
+        edificis = (
+            Edifici.actius
+            .select_for_update()
+            .filter(administradorFinca__isnull=False)
+        )
 
         for edifici in edificis:
             resum["edificis_processats"] += 1

--- a/backend/apps/seasons/signals.py
+++ b/backend/apps/seasons/signals.py
@@ -67,10 +67,15 @@ def crear_lligues_i_participacions(sender, instance, **kwargs):
     }
     logger.info(f"[SIGNAL] Lligues PROGRES: {lligues_progres}")
 
-    # ── 3. Edificis actius ─────────────────────────────────────────────────
-    # Entren tots els edificis actius, encara que ara mateix no tinguin score.
-    # Si encara no tenen puntuació, comencen amb 0 i poden progressar durant la temporada.
-    edificis = list(Edifici.actius.all())
+    # ── 3. Edificis actius gestionats ──────────────────────────────────────
+    # No inscrivim automàticament tots els edificis Open Data/CEE massius.
+    # Només entren edificis actius amb administrador de finca assignat.
+    # Si un edifici gestionat encara no té puntuació, entra amb 0 i pot progressar.
+    edificis = list(
+        Edifici.actius
+        .filter(administradorFinca__isnull=False)
+        .select_related("administradorFinca")
+    )
 
     if not edificis:
         logger.warning("Cap edifici actiu per assignar a la temporada id=%s.", instance.pk)
@@ -83,7 +88,7 @@ def crear_lligues_i_participacions(sender, instance, **kwargs):
     n = len(edificis_ordenats)
 
     logger.info(
-        "Temporada id=%s — %d edificis actius assignables a PROGRES.",
+        "Temporada id=%s — %d edificis actius gestionats assignables a PROGRES.",
         instance.pk, n
     )
 

--- a/backend/apps/seasons/tests.py
+++ b/backend/apps/seasons/tests.py
@@ -969,6 +969,7 @@ class TemporadaOpenDataSnapshotsAPITest(APITestCase):
             orientacioPrincipal="Sud",
             grupComparable=self.group,
             localitzacio=loc,
+            administradorFinca=self.user,
             puntuacioBase=puntuacio_base,
             puntuacioBaseOpenData=puntuacio_od,
             font_open_data=font_open_data,
@@ -996,6 +997,14 @@ class TemporadaOpenDataSnapshotsAPITest(APITestCase):
             "Carrer Sense Score",
             3,
         )
+        edifici_opendata_sense_admin = self._crear_edifici(
+            "Carrer CEE Sense Admin",
+            4,
+            puntuacio_od=77,
+            font_open_data=True,
+        )
+        edifici_opendata_sense_admin.administradorFinca = None
+        edifici_opendata_sense_admin.save(update_fields=["administradorFinca"])
 
         self.client.force_authenticate(user=self.admin)
         response = self.client.post(f"/api/seasons/{temporada.pk}/iniciar/")
@@ -1033,6 +1042,13 @@ class TemporadaOpenDataSnapshotsAPITest(APITestCase):
 
         self.assertEqual(participacio_sense_score.puntuacio, 0)
         self.assertEqual(participacio_sense_score.puntuacio_inicial, 0)
+
+        self.assertFalse(
+            Participacio.objects.filter(
+                edifici=edifici_opendata_sense_admin,
+                lliga__temporada=temporada,
+            ).exists()
+        )
 
     def test_generar_snapshot_temporada_es_idempotent(self):
         temporada = Temporada.objects.create(
@@ -1095,6 +1111,34 @@ class TemporadaOpenDataSnapshotsAPITest(APITestCase):
         self.assertEqual(snapshot.puntuacio, 88)
         self.assertEqual(snapshot.posicio, 1)
         self.assertEqual(snapshot.divisio, participacio.divisio)
+
+    def test_list_retorna_temporada_activa_i_anteriors_no_pendents(self):
+        activa = Temporada.objects.create(
+            nom="Temporada Activa",
+            dataInici="2026-01-01",
+            dataFi="2026-12-31",
+            estat=EstatTemporada.ACTIVA,
+        )
+        tancada = Temporada.objects.create(
+            nom="Temporada Tancada",
+            dataInici="2025-01-01",
+            dataFi="2025-12-31",
+            estat=EstatTemporada.TANCADA,
+        )
+        Temporada.objects.create(
+            nom="Temporada Pendent",
+            dataInici="2027-01-01",
+            dataFi="2027-12-31",
+            estat=EstatTemporada.PENDENT,
+        )
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get("/api/seasons/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = [item["id_temporada"] for item in response.data]
+
+        self.assertEqual(returned_ids, [activa.id_temporada, tancada.id_temporada])
 
     def test_endpoint_anteriors_retorna_només_temporades_tancades(self):
         tancada = Temporada.objects.create(

--- a/backend/apps/seasons/views.py
+++ b/backend/apps/seasons/views.py
@@ -1,4 +1,4 @@
-from django.db.models import Q
+from django.db.models import Q, Case, When, IntegerField
 from django.db import transaction
 from django.db.models import F
 from django.db.models.functions import Rank
@@ -40,6 +40,27 @@ class TemporadaViewSet(viewsets.ModelViewSet):
         ]:
             return [IsAuthenticated()]
         return [IsAdminSistema()]
+
+    def list(self, request, *args, **kwargs):
+        """Retorna la temporada actual i les temporades anteriors.
+
+        La llista està pensada pel frontend: no inclou temporades pendents,
+        perquè encara no formen part del cicle visible de ranking/progrés.
+        """
+        temporades = (
+            Temporada.objects
+            .filter(estat__in=[EstatTemporada.ACTIVA, EstatTemporada.TANCADA])
+            .order_by(
+                Case(
+                    When(estat=EstatTemporada.ACTIVA, then=0),
+                    default=1,
+                    output_field=IntegerField(),
+                ),
+                "-dataInici",
+                "-id_temporada",
+            )
+        )
+        return Response(TemporadaSerializer(temporades, many=True).data)
 
     @action(detail=False, methods=['post'], url_path='crear-i-iniciar')
     def crear_i_iniciar(self, request):


### PR DESCRIPTION
## Resum

Aquesta PR ajusta el flux de temporades i connecta dades reals per al panell d’administració.

L’objectiu principal és evitar que, en activar una temporada, s’inscriguin automàticament tots els edificis importats d’Open Data / CEE. Amb molts edificis carregats, aquest comportament podia ser lent i poc coherent funcionalment, perquè edificis sense administrador dins l’app passaven a participar en rankings actius.

També s’afegeixen endpoints i dades reals per substituir informació mock del panell admin.

---

## Canvis principals

### 1. Temporades només amb edificis gestionats

Abans, en iniciar una temporada, es creaven participacions per tots els edificis actius.

Ara només entren automàticament:

```text
Edifici actiu
+
administradorFinca assignat