### PR TITLE
chore(quality): add SonarCloud configuration

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,27 @@
+﻿name: SonarCloud
+
+on:
+  push:
+    branches:
+      - Desenvolupament
+  pull_request:
+    branches:
+      - Desenvolupament
+
+jobs:
+  sonarcloud:
+    name: SonarCloud analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: backend

--- a/backend/sonar-project.properties
+++ b/backend/sonar-project.properties
@@ -1,0 +1,19 @@
+﻿# SonarQube Cloud configuration for BuildRank backend.
+# Run the scanner from the backend/ directory.
+
+sonar.organization=scorelab-team
+sonar.projectKey=ScoreLab-Team_Backend-BuildRank
+sonar.projectName=Backend-BuildRank
+sonar.projectVersion=sprint3
+
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=apps,config
+sonar.tests=apps
+
+sonar.test.inclusions=apps/**/tests.py,apps/**/tests/**/*.py
+
+sonar.exclusions=**/migrations/**,staticfiles/**,media/**,**/__pycache__/**
+sonar.coverage.exclusions=apps/**/tests.py,apps/**/tests/**/*.py,apps/**/migrations/**,apps/**/admin.py,apps/**/management/commands/**
+
+sonar.python.coverage.reportPaths=../docs/testing/coverage/coverage.xml

--- a/docs/quality/sonar-summary-sprint3.md
+++ b/docs/quality/sonar-summary-sprint3.md
@@ -1,0 +1,59 @@
+﻿# SonarCloud summary Sprint 3
+
+## Informacio general
+
+Data: 25/05/2026
+Branca: qa/backend-sonar-sprint3
+Base: Desenvolupament actualitzat
+Ambit: backend Django / DRF de BuildRank
+
+## Estat inicial
+
+El projecte no tenia configuracio previa de SonarCloud al repositori.
+Durant aquesta fase hem creat el projecte Backend-BuildRank a SonarCloud dins l'organitzacio ScoreLab Team.
+
+## Valors SonarCloud
+
+- sonar.organization=scorelab-team
+- sonar.projectKey=ScoreLab-Team_Backend-BuildRank
+
+## Configuracio afegida
+
+S'han afegit aquests fitxers:
+
+- backend/sonar-project.properties
+- .github/workflows/sonarcloud.yml
+- docs/quality/sonar-summary-sprint3.md
+
+El fitxer sonar-project.properties configura l'analisi del backend des de la carpeta backend, analitzant apps i config.
+
+## Coverage
+
+SonarCloud importa la cobertura des del report generat previament amb coverage.py:
+
+- docs/testing/coverage/coverage.xml
+
+Coverage backend disponible:
+
+| Metrica | Resultat |
+|---|---:|
+| Tests backend | 751 |
+| Coverage global | 91% |
+| Statements analitzats | 13.483 |
+| Statements no coberts | 1.249 |
+
+## Workflow
+
+El workflow .github/workflows/sonarcloud.yml executa l'analisi de SonarCloud en push i pull request contra Desenvolupament.
+
+Per funcionar necessita el secret de GitHub Actions:
+
+- SONAR_TOKEN
+
+## Notes
+
+- No es versiona cap token ni secret.
+- El token queda configurat com a secret de GitHub Actions amb el nom SONAR_TOKEN.
+- Si SonarCloud Automatic Analysis esta activat, cal desactivar-lo per utilitzar el workflow i importar coverage.
+- La primera analisi automatica de SonarCloud no mostrava coverage perquè encara no estava configurada la importacio del coverage.xml.
+- Com que el token s'ha vist en una captura, es recomana revocar-lo i generar-ne un de nou.


### PR DESCRIPTION
## Resum

Aquesta PR afegeix la configuració inicial de SonarCloud per al backend de BuildRank.

L’objectiu és deixar preparat el projecte perquè SonarCloud pugui analitzar qualitat de codi, bugs potencials, code smells, duplicacions, security hotspots i coverage importat des de l’informe generat amb coverage.py.

## Canvis principals

- Afegit `backend/sonar-project.properties`.
- Afegit workflow `.github/workflows/sonarcloud.yml`.
- Afegida documentació a `docs/quality/sonar-summary-sprint3.md`.

## Configuració SonarCloud

Valors configurats:

- `sonar.organization=scorelab-team`
- `sonar.projectKey=ScoreLab-Team_Backend-BuildRank`
- `sonar.projectName=Backend-BuildRank`

El scanner s’executa amb `projectBaseDir: backend`, per això la configuració Sonar està dins de la carpeta `backend/`.

## Coverage

La cobertura s’importa des de l’informe generat prèviament amb coverage.py:

- `docs/testing/coverage/coverage.xml`

Coverage backend disponible:

- Tests backend: 751
- Coverage global: 91%
- Statements analitzats: 13.483
- Statements no coberts: 1.249

## GitHub Actions

S’ha afegit un workflow que executa SonarCloud en:

- push a `Desenvolupament`
- pull request cap a `Desenvolupament`

Perquè funcioni cal tenir configurat el secret:

- `SONAR_TOKEN`

## Notes

- No es versiona cap token ni secret.
- Si SonarCloud Automatic Analysis està activat, cal desactivar-lo per utilitzar el workflow de GitHub Actions i importar coverage correctament.
- La primera anàlisi automàtica de SonarCloud no mostrava coverage perquè encara no estava configurada la importació de `coverage.xml`.