### PR TITLE
docs: add QA, performance and data quality review for accounts

### DIFF
--- a/backend/docs/performance/accounts-performance-summary-sprint3.md
+++ b/backend/docs/performance/accounts-performance-summary-sprint3.md
@@ -1,0 +1,48 @@
+# Accounts Performance Summary - Sprint 3
+
+## Scope
+
+Aquest document resumeix l'estat de performance backend per l'Epic 1 (`accounts`): autenticacio, usuaris, rols, perfil, password reset, permisos i gestio de sessions.
+
+Branca revisada: `qa/backend-dia3-sonar-performance-data`.
+
+## Resultats disponibles
+
+No s'ha executat cap benchmark quantitatiu ni prova de carrega formal per `apps.accounts` en aquesta ronda. Per tant, aquest document no fixa latencies, throughput, percentils, consum de CPU/memoria ni temps de resposta exactes.
+
+Validacions relacionades executades:
+
+| Comando | Resultat |
+| --- | --- |
+| `docker compose exec web python manage.py check` | OK |
+| `docker compose exec web python manage.py makemigrations --check --dry-run` | OK, `No changes detected` |
+| `docker compose exec web python manage.py test apps.accounts -v 2` | OK, 102 tests executats |
+| `docker compose exec web coverage run manage.py test apps.accounts` | OK |
+| `docker compose exec web coverage report` | Coverage global reportada: 61% |
+
+## Senyals de performance coberts indirectament
+
+Les proves automatitzades inclouen escenaris que redueixen risc funcional en punts sensibles de performance i concurrencia:
+
+- Registre concurrent amb mateix email sense retorns 500.
+- Logins simultanis amb limit de sessions actives.
+- Actualitzacio concurrent d'email sense retorns 500.
+- Revocacio de tokens refresh en logout, password reset, bloqueig i suspensio d'usuari.
+- Consultes d'usuaris amb `select_related("profile")` en endpoints administratius, segons implementacio actual.
+
+Aquests resultats no substitueixen una prova de carrega. Només indiquen que els fluxos de concurrencia coberts pels tests no han fallat funcionalment.
+
+## Conclusions prudents
+
+L'estat actual es pot considerar apte per QA funcional de Sprint 3, pero la performance real queda pendent de validacio manual o automatitzada especifica. No hi ha evidencia en aquesta execucio de regressions evidents com errors 500 en escenaris concurrents coberts, pero tampoc hi ha dades suficients per afirmar objectius de latencia o capacitat.
+
+## Pendents
+
+- Pending: smoke manual de performance sobre endpoints principals d'accounts en entorn desplegat o entorn Docker local estable.
+- Pending: benchmark basic de login, registre, `me`, actualitzacio de perfil i password reset request/confirm.
+- Pending: prova de carrega curta amb concurrencia controlada per login i registre.
+- Pending: capturar metriques reals abans de definir llindars de Sprint o release.
+
+## Recomanacio QA
+
+No bloquejar el merge exclusivament per performance mentre no hi hagi criteris quantitatius acordats. Si el release requereix garantia operativa, executar com a minim un smoke manual amb temps observats i una prova curta de concurrencia abans de tancar l'Epic 1.

--- a/backend/docs/quality/accounts-data-quality-sprint3.md
+++ b/backend/docs/quality/accounts-data-quality-sprint3.md
@@ -1,0 +1,47 @@
+# Accounts Data Quality - Sprint 3
+
+## Scope
+
+Aquest document recull criteris i conclusions de qualitat de dades per l'Epic 1 backend (`accounts`): usuaris, autenticacio, rols, perfil, password reset, permisos, estat de compte i tokens.
+
+Branca revisada: `qa/backend-dia3-sonar-performance-data`.
+
+## Validacions executades
+
+| Comando | Resultat |
+| --- | --- |
+| `docker compose exec web python manage.py check` | OK |
+| `docker compose exec web python manage.py makemigrations --check --dry-run` | OK, `No changes detected` |
+| `docker compose exec web python manage.py test apps.accounts -v 2` | OK, 102 tests executats |
+| `docker compose exec web coverage run manage.py test apps.accounts` | OK |
+| `docker compose exec web coverage report` | Coverage global reportada: 61% |
+
+## Criteris de qualitat revisats
+
+- Integritat de model: `User` i `Profile` mantenen una relacio 1:1 i els tests treballen amb perfil associat.
+- Rols: els rols permesos es validen amb choices i els tests cobreixen assignacio, restriccions i permisos.
+- Passwords: registre i reset validen coincidencia, complexitat i token valid/invalid.
+- Tokens: logout, password reset i canvis d'estat de compte contemplen revocacio de refresh tokens.
+- Estat de compte: bloqueig, suspensio, desbloqueig i reactivacio es validen amb canvis persistits al perfil.
+- Privadesa en password reset: la sol.licitud no retorna `uid` ni `token` a l'API i evita enumeracio d'usuaris.
+- Concurrencia: proves especifiques cobreixen duplicats de registre, limit de sessions i actualitzacio d'email.
+- Migracions: `makemigrations --check --dry-run` confirma que no hi ha divergencia entre models i migracions.
+
+## Conclusions
+
+La qualitat de dades per `accounts` queda validada a nivell de QA automatitzada de Sprint 3. Els resultats disponibles indiquen que no hi ha migracions pendents, que les validacions principals d'identitat i rols funcionen, i que els fluxos sensibles de token/password reset tenen proves de regressio.
+
+Les conclusions son prudents: no s'ha fet una auditoria manual de base de dades productiva ni una reconciliacio de dades reals. Per tant, aquest document avalua el comportament del codi i de les proves automatitzades, no l'estat d'un dataset de produccio.
+
+## Decisions de QA
+
+- Acceptar la qualitat de dades de l'Epic 1 per Sprint 3 amb els tests actuals en verd.
+- Considerar obligatori repetir `makemigrations --check --dry-run` si es modifiquen models, serializers o camps de perfil.
+- Considerar obligatoris tests especifics per qualsevol canvi en rols, estats de compte, revocacio de tokens o password reset.
+- No introduir canvis funcionals en aquesta tasca; aquest document nomes registra l'estat de QA.
+
+## Pendents i recomanacions
+
+- Pending: smoke manual contra un entorn amb dades representatives per verificar coherencia visual/API de perfil, rol i estat de compte.
+- Pending: revisar dades reals o fixtures representatives si es vol certificar absencia de duplicats historics, perfils orfes o rols antics.
+- Recomanat: mantenir fixtures o factories estables per usuaris amb rols `owner`, `tenant`, `admin` i superuser.

--- a/backend/docs/testing/accounts-qa-summary-sprint3.md
+++ b/backend/docs/testing/accounts-qa-summary-sprint3.md
@@ -1,0 +1,53 @@
+# Accounts QA Summary - Sprint 3
+
+## Scope
+
+Aquest resum cobreix la QA backend de l'Epic 1 per al modul `accounts`: autenticacio, usuaris, rols, perfil, password reset, permisos RBAC/ABAC, estats de compte i sessions/token JWT.
+
+Branca revisada: `qa/backend-dia3-sonar-performance-data`.
+
+## Execucio de proves
+
+Comandos executats abans de generar aquest document:
+
+| Comando | Resultat |
+| --- | --- |
+| `docker compose exec web python manage.py check` | OK |
+| `docker compose exec web python manage.py makemigrations --check --dry-run` | OK, `No changes detected` |
+| `docker compose exec web python manage.py test apps.accounts -v 2` | OK, 102 tests executats |
+| `docker compose exec web coverage run manage.py test apps.accounts` | OK |
+| `docker compose exec web coverage report` | Coverage global reportada: 61% |
+
+## Cobertura funcional observada
+
+Els tests d'`apps.accounts` cobreixen els fluxos principals de l'Epic 1:
+
+- Registre d'usuaris i validacions de contrasenya.
+- Login amb JWT, logout i revocacio de tokens refresh.
+- Limitacio de sessions actives i proves de concurrencia per login/registre/actualitzacio d'email.
+- Endpoints `me`, perfil, avatar i canvi de dades basiques de compte.
+- Assignacio i actualitzacio de rols permesos.
+- Permisos RBAC i ABAC per perfils d'usuari, incloent casos 401/403.
+- Gestio d'estat de compte per admin de sistema: bloqueig, desbloqueig, suspensio i reactivacio.
+- Password reset: sol.licitud sense enumeracio d'usuaris, confirmacio amb token valid/invalid, mismatch de password i revocacio de sessions actives.
+- Google OAuth amb mocks de verificacio de token, alta/login i validacio de rol.
+- Casos especifics de verificacio pendent d'admin de finca.
+
+## Conclusions de QA
+
+El paquet `apps.accounts` queda en estat verd per a les proves automatitzades executades en aquesta branca. No hi ha canvis pendents de migracions i el `manage.py check` no reporta errors de configuracio del projecte.
+
+La cobertura global del projecte es mante al 61%. Aquesta xifra no implica cobertura completa de l'Epic 1, pero combinada amb els 102 tests d'`accounts` dona una base raonable per validar els fluxos critics d'autenticacio, permisos i gestio d'usuaris.
+
+## Decisions
+
+- Acceptar la QA automatitzada d'`apps.accounts` per Sprint 3 amb els resultats disponibles.
+- No bloquejar per performance per falta de metriques quantitatives executades en aquesta ronda; queda documentat al resum de performance.
+- Mantenir com a criteri de regressio que `manage.py check`, `makemigrations --check --dry-run` i `test apps.accounts` continuin en verd abans de merge.
+- Tractar qualsevol canvi futur en autenticacio, rols, password reset o revocacio de tokens com a area de risc alt i requerir proves especifiques.
+
+## Riscos i pendents
+
+- Coverage global del 61%: suficient com a senyal general, pero millorable si es vol elevar el llindar de qualitat del backend complet.
+- No s'ha documentat cap prova E2E manual completa contra frontend en aquesta execucio.
+- No s'han executat proves de carrega o benchmark real per endpoints d'accounts en aquesta ronda.


### PR DESCRIPTION
## Resum

Revisió i documentació de QA backend per al Sprint 3 Dia 3 centrada en l’EPIC 1 (`accounts`).

Aquesta PR només afegeix documentació de qualitat i no introdueix canvis funcionals.

## Inclou

* Resum de QA d’accounts
* Revisió de performance d’accounts
* Revisió de qualitat de dades d’accounts

## Validacions executades

* `manage.py check`
* `makemigrations --check --dry-run`
* `python manage.py test apps.accounts -v 2`
* `coverage run manage.py test apps.accounts`
* `coverage report`

## Resultats

* 102 tests executats correctament
* Coverage global backend: 61%
* Fluxos d’autenticació, autorització i concurrència validats
* No hi ha migracions pendents detectades

## Notes

* No s’inclou treball d’accessibilitat
* No s’han inventat mètriques de performance; els pendents queden documentats explícitament
* No s’ha modificat cap lògica funcional del backend
