### PR TITLE
chore: optimize docker build context with dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Python
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/*.pyd
+
+# Virtual envs
+**/.venv/
+**/venv/
+**/env/
+
+# Git
+.git
+.gitignore
+
+# IDE
+.idea/
+.vscode/
+
+# Testing / coverage
+.coverage
+coverage.xml
+htmlcov/
+.pytest_cache/
+
+# Logs
+*.log
+
+# Local databases
+*.sqlite3
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Build artifacts
+dist/
+build/
+
+# Media/static generated
+backend/media/
+backend/staticfiles/
+
+# Large temp/docs artifacts
+out/
+docs/testing/logs/
+docs/testing/coverage/
+docs/performance/logs/
+
+# Node
+node_modules/
+
+# Docker overrides
+docker-compose.override.yml


### PR DESCRIPTION
## Resum

Aquesta PR afegeix un `.dockerignore` per reduir el Docker build context i evitar enviar fitxers innecessaris durant els builds.

## Problema detectat

El build estava transferint aproximadament 5GB de context Docker perquè s’incloïa la carpeta `.venv` i altres artefactes locals.

Això provocava:

* builds molt lents
* càrrega innecessària al CI
* consum elevat d’espai i temps
* pitjor experiència de desenvolupament

## Solució

S’ha afegit un `.dockerignore` excloent:

* `.venv`
* caches Python
* coverage
* logs
* artefactes temporals
* fitxers d’IDE
* media/static generats
* altres fitxers locals innecessaris

## Resultat

Build context:

* abans: ~5.36GB
* ara: ~5.84MB

El runtime s’ha validat correctament:

* web OK
* celery OK
* db healthy
* redis healthy
* nginx OK
* ollama healthy

No s’introdueixen canvis funcionals.
