### PR TITLE
chore: optimitzar el context de build Docker amb .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Python
+**/__pycache__/
+**/*.pyc
+**/*.pyo
+**/*.pyd
+
+# Virtual envs
+**/.venv/
+**/venv/
+**/env/
+
+# Git
+.git
+.gitignore
+
+# IDE
+.idea/
+.vscode/
+
+# Testing / coverage
+.coverage
+coverage.xml
+htmlcov/
+.pytest_cache/
+
+# Logs
+*.log
+
+# Local databases
+*.sqlite3
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Build artifacts
+dist/
+build/
+
+# Media/static generated
+backend/media/
+backend/staticfiles/
+
+# Large temp/docs artifacts
+out/
+docs/testing/logs/
+docs/testing/coverage/
+docs/performance/logs/
+
+# Node
+node_modules/
+
+# Docker overrides
+docker-compose.override.yml


### PR DESCRIPTION
## Resum

Aquesta PR afegeix un `.dockerignore` per reduir el context de build Docker i evitar enviar fitxers innecessaris durant els builds del backend.

## Problema detectat

El build Docker estava transferint aproximadament 5GB de context perquè s’incloïa la carpeta `.venv` i altres artefactes locals.

Això provocava:

* builds molt més lents
* més càrrega al CI
* més consum d’espai i temps
* pitjor experiència de desenvolupament

## Solució aplicada

S’ha creat un `.dockerignore` excloent:

* `.venv`
* caches Python
* coverage
* logs
* fitxers temporals
* fitxers d’IDE
* media/static generats
* altres artefactes locals innecessaris

## Resultats

Context Docker:

* abans: ~5.36GB
* ara: ~5.84MB

S’ha validat correctament:

* build Docker OK
* runtime OK
* web OK
* celery_worker OK
* db healthy
* redis healthy
* nginx OK
* ollama healthy

## Notes

No s’introdueixen canvis funcionals al backend.
