### PR TITLE
fix(deploy): restore full Virtech stack with media support

### DIFF
--- a/docker-compose.virtech.yml
+++ b/docker-compose.virtech.yml
@@ -1,6 +1,7 @@
-﻿version: "2.4"
+version: "2.4"
 
 services:
+
   db:
     image: postgres:16-alpine
     restart: unless-stopped
@@ -14,6 +15,33 @@ services:
       timeout: 5s
       retries: 10
 
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    expose:
+      - "6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  ollama:
+    image: ollama/ollama:latest
+    restart: unless-stopped
+    volumes:
+      - /opt/buildrank/data/ollama:/root/.ollama
+    expose:
+      - "11434"
+    environment:
+      OLLAMA_MAX_LOADED_MODELS: "1"
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+
   web:
     build: ./backend
     restart: unless-stopped
@@ -26,8 +54,26 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     expose:
       - "8000"
+
+  celery_worker:
+    build: ./backend
+    restart: unless-stopped
+    env_file:
+      - /opt/buildrank/env/backend.env
+    command: celery -A config worker --loglevel=info --concurrency=1
+    volumes:
+      - media_volume:/app/media
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      ollama:
+        condition: service_healthy
 
   nginx:
     image: nginx:1.27-alpine

--- a/nginx/nginx.virtech.conf
+++ b/nginx/nginx.virtech.conf
@@ -1,4 +1,4 @@
-﻿upstream django_app {
+upstream django_app {
     server web:8000;
 }
 


### PR DESCRIPTION
Aquesta PR restaura la configuració completa de desplegament de Virtech, mantenint els serveis necessaris del release actual: PostgreSQL, Redis, Ollama, Django/Gunicorn, Celery worker i Nginx.

També manté el suport de fitxers media perquè els avatars pujats pel backend siguin accessibles des de Nginx mitjançant /media/.

El canvi queda limitat a la configuració de deploy:
- docker-compose.virtech.yml
- nginx/nginx.virtech.conf

No modifica models, serializers, views, migracions ni lògica funcional del backend.