### PR TITLE
ci: run SonarCloud only on main project repository

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -24,6 +24,7 @@ on:
       - "docs/**"
       - "README.md"
       - ".github/workflows/backend-ci.yml"
+      - ".github/workflows/**"
 
   workflow_dispatch:
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,6 +12,7 @@ jobs:
   sonarcloud:
     name: SonarCloud analysis
     runs-on: ubuntu-latest
+    if: github.repository == 'ScoreLab-Team/Backend-BuildRank'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Aquesta PR evita que el workflow de SonarCloud falli en forks o repositoris mirall que no tenen accés al projecte SonarCloud original ni al secret SONAR_TOKEN corresponent.

El job de SonarCloud només s’executa al repositori principal ScoreLab-Team/Backend-BuildRank. En forks o repositoris de lliurament, el job queda omès en lloc de fallar per “Project not found”.

No modifica codi funcional.