### PR TITLE
ci: sync workflow fork guard to main

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -24,6 +24,7 @@ on:
       - "docs/**"
       - "README.md"
       - ".github/workflows/backend-ci.yml"
+      - ".github/workflows/**"
 
   workflow_dispatch:
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,6 +12,7 @@ jobs:
   sonarcloud:
     name: SonarCloud analysis
     runs-on: ubuntu-latest
+    if: github.repository == 'ScoreLab-Team/Backend-BuildRank'
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Aquesta PR porta a main el petit ajust de CI que ja està a Desenvolupament.

Canvis:
- Limita l’execució de SonarCloud al repositori principal ScoreLab-Team/Backend-BuildRank.
- Inclou canvis de workflows dins dels paths que disparen el Backend CI.

Motiu:
- Evitar que el fork/repositori de l’organització de l’assignatura falli per no tenir accés al projecte SonarCloud original ni al secret SONAR_TOKEN.
- Mantenir main alineada amb Desenvolupament a nivell de configuració de CI.

No modifica codi funcional.