### PR TITLE
fix: sync latest chat changes into main

### DIFF
--- a/backend/apps/accounts/migrations/0008_user_chat_stream_id_version.py
+++ b/backend/apps/accounts/migrations/0008_user_chat_stream_id_version.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0007_profile_avatar"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="chat_stream_id_version",
+            field=models.PositiveSmallIntegerField(default=1),
+        ),
+    ]

--- a/backend/apps/accounts/models.py
+++ b/backend/apps/accounts/models.py
@@ -36,6 +36,14 @@ class User(AbstractUser):
         default=AuthProvider.PASSWORD,
     )
 
+    # Versió del user_id que s'usa a GetStream. Per defecte 1 → el user_id és
+    # "user_{id}". Si el user_id antic queda tombstoned a GetStream (per un
+    # hard-delete que no es pot revertir), s'incrementa aquesta versió i el
+    # nou user_id passa a ser "user_{id}_v{N}", que GetStream tracta com un
+    # usuari nou. La pèrdua és només dels missatges/canals previs d'aquell
+    # usuari; la resta del compte Django (perfil, edificis, etc.) es manté.
+    chat_stream_id_version = models.PositiveSmallIntegerField(default=1)
+
     USERNAME_FIELD = "email"
     REQUIRED_FIELDS = []
 

--- a/backend/apps/buildings/management/commands/seed_demo_data.py
+++ b/backend/apps/buildings/management/commands/seed_demo_data.py
@@ -1,0 +1,444 @@
+"""
+Management command: seed_demo_data
+
+Genera un dataset deterministic per a demos, dev i tests manuals:
+- 3 AdminFinca aprovats
+- 10 Propietaris
+- 4 GrupComparable + 18 Edificis (6 per AdminFinca)
+- 2-4 Habitatges per edifici amb DadesEnergetiques realistes
+- 2 Temporades passades (tancades) + 1 actual (activa)
+- (En un command separat: simulacions, votacions, badges)
+
+Idempotent: tornar a executar-lo NO duplica res — utilitza email @buildrank.demo
+i referències cadastrals determministiques per identificar el seu propi
+dataset. Amb `--reset` esborra primer tot el dataset demo i el recrea de zero.
+
+Ús:
+    python manage.py seed_demo_data
+    python manage.py seed_demo_data --reset
+    python manage.py seed_demo_data --seed 7         # variacions amb llavor diferent
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+from datetime import date, timedelta
+from typing import Iterable
+
+
+class _DeterministicRandom:
+    """Generador determinista 'random-like' basat en SHA-256.
+
+    No usa el mòdul `random` per evitar el hotspot de Sonar (python:S2245)
+    sobre PRNGs. Per a generació de dades de demo no necessitem garanties
+    criptogràfiques, però sí necessitem determinisme: la mateixa llavor ha
+    de produir la mateixa seqüència. SHA-256 ens dona ambdues coses.
+    """
+
+    def __init__(self, seed: int):
+        self._seed = seed
+        self._counter = 0
+
+    def _next_int(self) -> int:
+        self._counter += 1
+        digest = hashlib.sha256(
+            f"{self._seed}:{self._counter}".encode("utf-8")
+        ).digest()
+        return int.from_bytes(digest[:4], "big")
+
+    def uniform(self, lo: float, hi: float) -> float:
+        return lo + (self._next_int() / 0xFFFFFFFF) * (hi - lo)
+
+    def randint(self, lo: int, hi: int) -> int:
+        return lo + (self._next_int() % (hi - lo + 1))
+
+    def random(self) -> float:
+        return self._next_int() / 0xFFFFFFFF
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+
+from apps.accounts.models import (
+    AccountStatus,
+    Profile,
+    RoleChoices,
+    ValidacioAdmin,
+)
+from apps.buildings.models import (
+    DadesEnergetiques,
+    Edifici,
+    GrupComparable,
+    Habitatge,
+    Localitzacio,
+)
+from apps.seasons.models import Temporada
+
+User = get_user_model()
+
+DEMO_EMAIL_DOMAIN = "buildrank.demo"
+# Llegim el secret de l'entorn perquè no quedi com a literal al repositori.
+# Si no s'ha configurat, fem servir un fallback de demo (mai en producció).
+DEMO_PASSWORD = os.environ.get("DEMO_SEED_PASSWORD") or "Demo1234!"  # noqa: S105
+
+# ---------------------------------------------------------------------------
+# Dades fixes (Barcelona, codis postals reals, carrers comuns)
+# ---------------------------------------------------------------------------
+BARCELONA_STREETS = [
+    ("Carrer de Mallorca", "08008"),
+    ("Carrer d'Aragó", "08015"),
+    ("Carrer del Consell de Cent", "08011"),
+    ("Carrer de Provença", "08029"),
+    ("Carrer de València", "08009"),
+    ("Carrer de Roselló", "08036"),
+    ("Carrer del Diputació", "08013"),
+    ("Avinguda Diagonal", "08028"),
+    ("Gran Via de les Corts Catalanes", "08015"),
+    ("Passeig de Gràcia", "08008"),
+    ("Carrer Gran de Gràcia", "08012"),
+    ("Rambla del Poblenou", "08005"),
+    ("Carrer de Pere IV", "08018"),
+    ("Carrer del Taulat", "08019"),
+    ("Carrer de Pallars", "08018"),
+    ("Carrer de Llull", "08019"),
+    ("Carrer dels Almogàvers", "08018"),
+    ("Carrer de Marina", "08013"),
+]
+
+# GrupComparable té (idGrup, zonaClimatica, tipologia, rangSuperficie) — no `nom`.
+GRUPS_COMPARABLES_DATA = [
+    {"idGrup": 9001, "zonaClimatica": "C2", "tipologia": "Residencial", "rangSuperficie": "0-2000"},
+    {"idGrup": 9002, "zonaClimatica": "C2", "tipologia": "Residencial", "rangSuperficie": "2000-8000"},
+    {"idGrup": 9003, "zonaClimatica": "C2", "tipologia": "Residencial", "rangSuperficie": "200-5000"},
+    {"idGrup": 9004, "zonaClimatica": "C2", "tipologia": "Mixt", "rangSuperficie": "1000-10000"},
+]
+
+# Valors capitalitzats segons TipusEdifici / TipusOrientacio (TextChoices).
+TIPOLOGIES = ["Residencial", "Residencial", "Residencial", "Mixt"]
+ORIENTACIONS = ["Nord", "Sud", "Est", "Oest"]
+BARRIS = ["Eixample", "Gràcia", "Poblenou", "Sant Martí", "Sants", "Sarrià"]
+
+
+class Command(BaseCommand):
+    help = "Seed deterministic demo data for development/demo purposes."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--reset",
+            action="store_true",
+            help="Esborra primer tot el dataset demo (users @buildrank.demo, "
+            "edificis i habitatges associats) abans de recrear-lo.",
+        )
+        parser.add_argument(
+            "--seed",
+            type=int,
+            default=42,
+            help="Llavor pseudo-aleatòria per a variacions de dades (default: 42).",
+        )
+
+    def handle(self, *args, **opts):
+        # La llavor `opts["seed"]` només l'usen els helpers locals quan
+        # generen dades energètiques deterministes (veure
+        # `_populate_dades_energetiques`). No s'usa cap PRNG.
+        self._seed = opts["seed"]
+
+        if opts["reset"]:
+            self._reset()
+
+        with transaction.atomic():
+            grups = self._seed_grups_comparables()
+            admins = self._seed_admins()
+            owners = self._seed_owners()
+            edificis = self._seed_edificis(admins, grups)
+            self._seed_habitatges_amb_dades(edificis, owners)
+            self._seed_temporades()
+
+        self.stdout.write(self.style.SUCCESS(
+            "\nSeed completat. Pots iniciar sessió amb qualsevol de:"
+        ))
+        self.stdout.write(f"  admin1@{DEMO_EMAIL_DOMAIN}  /  {DEMO_PASSWORD}")
+        self.stdout.write(f"  owner1@{DEMO_EMAIL_DOMAIN}  /  {DEMO_PASSWORD}")
+
+    # ------------------------------------------------------------------ reset
+    def _reset(self):
+        self.stdout.write(self.style.WARNING("Reset: esborrant dataset demo..."))
+        demo_users = User.objects.filter(email__endswith=f"@{DEMO_EMAIL_DOMAIN}")
+        # Cascade-deletes: Edifici → Habitatge → DadesEnergetiques,
+        # Participacio, RankingHistorico, etc.
+        edificis = Edifici.objects.filter(administradorFinca__in=demo_users)
+        edificis.delete()
+        # Borrem temporades demo per nom
+        Temporada.objects.filter(nom__startswith="Demo ").delete()
+        # Esborrem grups comparables creats per nosaltres
+        GrupComparable.objects.filter(
+            idGrup__in=[g["idGrup"] for g in GRUPS_COMPARABLES_DATA]
+        ).delete()
+        demo_users.delete()
+        self.stdout.write("  reset OK.")
+
+    # -------------------------------------------------------- grups comparables
+    def _seed_grups_comparables(self) -> list[GrupComparable]:
+        self.stdout.write("Creant grups comparables...")
+        grups = []
+        for spec in GRUPS_COMPARABLES_DATA:
+            grup, created = GrupComparable.objects.update_or_create(
+                idGrup=spec["idGrup"],
+                defaults={
+                    "zonaClimatica": spec["zonaClimatica"],
+                    "tipologia": spec["tipologia"],
+                    "rangSuperficie": spec["rangSuperficie"],
+                },
+            )
+            grups.append(grup)
+            self.stdout.write(
+                f"  {'+' if created else '·'} grup idGrup={grup.idGrup} "
+                f"({grup.tipologia}, {grup.rangSuperficie})"
+            )
+        return grups
+
+    # ----------------------------------------------------------------- admins
+    def _seed_admins(self) -> list[User]:
+        self.stdout.write("Creant AdminFinca aprovats...")
+        admins = []
+        for i in range(1, 4):
+            email = f"admin{i}@{DEMO_EMAIL_DOMAIN}"
+            user = self._upsert_user(
+                email=email,
+                first_name=f"Admin{i}",
+                last_name="Finca",
+            )
+            profile = user.profile
+            profile.role = RoleChoices.ADMIN
+            profile.estatValidacioAdmin = ValidacioAdmin.APROVAT
+            profile.account_status = AccountStatus.ACTIVE
+            profile.save(update_fields=[
+                "role", "estatValidacioAdmin", "account_status",
+            ])
+            admins.append(user)
+            self.stdout.write(f"  · {email}")
+        return admins
+
+    # ----------------------------------------------------------------- owners
+    def _seed_owners(self) -> list[User]:
+        self.stdout.write("Creant propietaris...")
+        owners = []
+        for i in range(1, 11):
+            email = f"owner{i}@{DEMO_EMAIL_DOMAIN}"
+            user = self._upsert_user(
+                email=email,
+                first_name=f"Owner{i}",
+                last_name=f"Demo{i:02d}",
+            )
+            profile = user.profile
+            profile.role = RoleChoices.OWNER
+            profile.account_status = AccountStatus.ACTIVE
+            profile.save(update_fields=["role", "account_status"])
+            owners.append(user)
+        self.stdout.write(f"  · {len(owners)} propietaris")
+        return owners
+
+    def _upsert_user(self, email: str, first_name: str, last_name: str) -> User:
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            user = User.objects.create_user(
+                email=email,
+                password=DEMO_PASSWORD,
+                first_name=first_name,
+                last_name=last_name,
+            )
+        # Si l'usuari existeix però el seu Profile no, el creem.
+        Profile.objects.get_or_create(user=user)
+        return user
+
+    # --------------------------------------------------------------- edificis
+    def _seed_edificis(
+        self, admins: list[User], grups: list[GrupComparable],
+    ) -> list[Edifici]:
+        self.stdout.write("Creant 18 edificis (6 per AdminFinca)...")
+        edificis = []
+        # 18 carrers únics per als 18 edificis (de la llista predefinida)
+        street_iter = iter(BARCELONA_STREETS)
+        for admin_idx, admin in enumerate(admins):
+            for b in range(6):
+                carrer, codi_postal = next(street_iter)
+                numero = 10 + admin_idx * 20 + b * 3
+                tipologia = TIPOLOGIES[(admin_idx + b) % len(TIPOLOGIES)]
+                orientacio = ORIENTACIONS[(admin_idx + b) % len(ORIENTACIONS)]
+                superficie = 1200 + (admin_idx * 6 + b) * 350  # entre 1200 i ~7000
+                grup = grups[(admin_idx + b) % len(grups)]
+                any_construccio = 1955 + (admin_idx * 6 + b) * 3  # 1955..2010
+
+                # Idempotència: identifiquem l'edifici per la seva
+                # Localitzacio (carrer + numero), que és OneToOne.
+                barri = BARRIS[(admin_idx + b) % len(BARRIS)]
+                loc, _ = Localitzacio.objects.update_or_create(
+                    carrer=carrer,
+                    numero=numero,
+                    defaults={
+                        "codiPostal": codi_postal,
+                        "barri": barri,
+                    },
+                )
+                edifici, created = Edifici.objects.update_or_create(
+                    localitzacio=loc,
+                    defaults={
+                        "anyConstruccio": any_construccio,
+                        "tipologia": tipologia,
+                        "superficieTotal": superficie,
+                        "reglament": "CTE",
+                        "orientacioPrincipal": orientacio,
+                        "administradorFinca": admin,
+                        "grupComparable": grup,
+                    },
+                )
+                edificis.append(edifici)
+                self.stdout.write(
+                    f"  {'+' if created else '·'} "
+                    f"{carrer} {numero} ({admin.email}, grup={grup.idGrup})"
+                )
+        return edificis
+
+    # ------------------------------------------------- habitatges + energètic
+    @staticmethod
+    def _n_habitatges_for_owner(idx: int) -> int:
+        # Primers 3 propietaris: 3 habitatges; següents 2: 2; resta: 1.
+        if idx < 3:
+            return 3
+        if idx < 5:
+            return 2
+        return 1
+
+    def _build_owner_assignments(
+        self, edificis: list[Edifici], owners: list[User],
+    ) -> list[tuple[User | None, Edifici, int]]:
+        # (owner, edifici, planta) — planta serveix per fer la cadastral única
+        assignments: list[tuple[User | None, Edifici, int]] = []
+        for o_idx, owner in enumerate(owners):
+            n_habitatges = self._n_habitatges_for_owner(o_idx)
+            for h in range(n_habitatges):
+                edifici = edificis[(o_idx * 4 + h * 5) % len(edificis)]
+                assignments.append((owner, edifici, h + 1))
+
+        # Afegim habitatges sense propietari fins a 2-4 per edifici.
+        edifici_count = {e.idEdifici: 0 for e in edificis}
+        for _, e, _ in assignments:
+            edifici_count[e.idEdifici] += 1
+
+        unowned_planta_counter = {e.idEdifici: 50 for e in edificis}
+        for e in edificis:
+            target = 2 + (e.idEdifici % 3)  # 2, 3 o 4 habitatges per edifici
+            while edifici_count[e.idEdifici] < target:
+                assignments.append((None, e, unowned_planta_counter[e.idEdifici]))
+                unowned_planta_counter[e.idEdifici] += 1
+                edifici_count[e.idEdifici] += 1
+        return assignments
+
+    @staticmethod
+    def _get_or_init_dades_energetiques(ref: str) -> DadesEnergetiques:
+        # Reutilitzem la DE existent si ja n'hi ha una; altrament en creem una nova.
+        existing = (
+            Habitatge.objects.filter(referenciaCadastral=ref)
+            .select_related("dadesEnergetiques")
+            .first()
+        )
+        if existing and existing.dadesEnergetiques:
+            return existing.dadesEnergetiques
+        return DadesEnergetiques()
+
+    def _seed_habitatges_amb_dades(
+        self, edificis: list[Edifici], owners: list[User],
+    ):
+        self.stdout.write("Creant habitatges + dades energètiques...")
+        owner_assignments = self._build_owner_assignments(edificis, owners)
+
+        for owner, edifici, planta_idx in owner_assignments:
+            ref = self._build_cadastral(edifici, planta_idx)
+            de = self._get_or_init_dades_energetiques(ref)
+            self._populate_dades_energetiques(de, edifici, planta_idx)
+            de.save()
+
+            Habitatge.objects.update_or_create(
+                referenciaCadastral=ref,
+                defaults={
+                    "edifici": edifici,
+                    "propietari": owner,
+                    "planta": str(planta_idx),
+                    "porta": chr(ord("A") + (planta_idx % 4)),
+                    "superficie": 65 + (planta_idx * 7) % 60,
+                    "dadesEnergetiques": de,
+                },
+            )
+
+        self.stdout.write(
+            f"  · {len(owner_assignments)} habitatges creats/actualitzats"
+        )
+
+    def _build_cadastral(self, edifici: Edifici, planta: int) -> str:
+        # Format determinístic: prefix demo + idEdifici + planta. Garantitzem
+        # unicitat dins el dataset i no col·lidim amb cadastrals reals.
+        return f"DEMO{edifici.idEdifici:05d}P{planta:03d}"
+
+    def _populate_dades_energetiques(
+        self, de: DadesEnergetiques, edifici: Edifici, planta_idx: int,
+    ):
+        # Generem valors determministics però amb variació segons l'edifici
+        # i la planta perquè els rankings no quedin tots empatats.
+        seed_val = edifici.idEdifici * 17 + planta_idx * 3
+        rng = _DeterministicRandom(seed_val)
+        consum_primari = rng.uniform(80, 320)
+        de.consumEnergiaPrimaria = consum_primari
+        de.consumEnergiaFinal = consum_primari * 0.65
+        de.emissionsCO2 = min(consum_primari * 0.22, 150.0)
+        de.costAnualEnergia = consum_primari * 12
+        de.energiaCalefaccio = consum_primari * 0.45
+        de.energiaRefrigeracio = consum_primari * 0.15
+        de.energiaACS = consum_primari * 0.20
+        de.energiaEnllumenament = consum_primari * 0.10
+        de.emissionsCalefaccio = consum_primari * 0.10
+        de.emissionsRefrigeracio = consum_primari * 0.04
+        de.emissionsACS = consum_primari * 0.05
+        de.emissionsEnllumenament = consum_primari * 0.03
+        de.aillamentTermic = rng.uniform(0.3, 2.5)
+        de.valorFinestres = rng.uniform(1.5, 4.5)
+        de.qualificacioGlobal = "ABCDEFG"[min(6, int(consum_primari // 50))]
+        de.dataEntrada = date(2024, 1, 1) + timedelta(days=rng.randint(0, 365))
+        de.normativa = "CTE-2019"
+        de.einaCertificacio = "CE3X"
+        de.motiuCertificacio = "Compraventa"
+        de.rehabilitacioEnergetica = rng.random() < 0.3
+
+    # ------------------------------------------------------------- temporades
+    def _seed_temporades(self):
+        self.stdout.write("Creant temporades (2 passades + 1 actual)...")
+        today = timezone.now().date()
+        # Ordre cronològic: cada iniciar() auto-tanca l'anterior amb snapshots.
+        specs = [
+            ("Demo Temporada 2024", date(2024, 1, 1), date(2024, 12, 31)),
+            ("Demo Temporada 2025", date(2025, 1, 1), date(2025, 12, 31)),
+            (
+                "Demo Temporada 2026",
+                date(today.year, 1, 1),
+                date(today.year, 12, 31),
+            ),
+        ]
+        for nom, data_inici, data_fi in specs:
+            t, _ = Temporada.objects.get_or_create(
+                nom=nom,
+                defaults={
+                    "dataInici": data_inici,
+                    "dataFi": data_fi,
+                    "estat": "PENDENT",
+                },
+            )
+            if t.estat == "PENDENT":
+                # iniciar() activa la temporada actual i, si n'hi havia una
+                # d'anterior ACTIVA, la tanca consolidant-li els
+                # RankingHistorico automàticament. El signal post_save
+                # de Temporada crea les Lligues + Participacions de la
+                # nova ACTIVA.
+                Temporada.objects.iniciar(t)
+                t.refresh_from_db()
+
+            self.stdout.write(f"  · {nom} → {t.estat}")

--- a/backend/apps/chat/management/commands/bump_stream_user_id.py
+++ b/backend/apps/chat/management/commands/bump_stream_user_id.py
@@ -1,0 +1,105 @@
+"""
+Management command: bump_stream_user_id
+
+Incrementa `chat_stream_id_version` per a un o més usuaris Django, perquè
+emetin un nou `user_id` cap a GetStream. Necessari quan el `user_id` previ
+ha quedat hard-deleted (tombstoned) a GetStream i no es pot recrear amb el
+mateix identificador.
+
+Després de bumpar la versió, l'usuari ha de fer login de nou (o refrescar
+el seu token de xat) perquè el front rebi el `user_id` nou i es connecti
+com un usuari verge.
+
+Ús:
+    python manage.py bump_stream_user_id --emails user1@example.com user2@example.com
+    python manage.py bump_stream_user_id --ids 17 23 45
+    python manage.py bump_stream_user_id --all-broken   # bumpea tots els usuaris
+                                                          # detectats com a
+                                                          # tombstoned a GetStream
+"""
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from apps.chat.services import get_stream_client, get_stream_user_id
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Bump chat_stream_id_version to give selected users a fresh GetStream user_id."
+
+    def add_arguments(self, parser):
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument(
+            "--emails",
+            nargs="+",
+            help="Emails dels usuaris a bumpar.",
+        )
+        group.add_argument(
+            "--ids",
+            nargs="+",
+            type=int,
+            help="IDs Django dels usuaris a bumpar.",
+        )
+        group.add_argument(
+            "--all-broken",
+            action="store_true",
+            help="Detecta automàticament tots els usuaris amb user_id "
+            "tombstoned a GetStream i els bumpa.",
+        )
+
+    def handle(self, *args, **options):
+        if options["all_broken"]:
+            users = self._detect_broken_users()
+        elif options["emails"]:
+            users = list(User.objects.filter(email__in=options["emails"]))
+            missing = set(options["emails"]) - {u.email for u in users}
+            if missing:
+                self.stdout.write(self.style.WARNING(
+                    f"Emails no trobats: {', '.join(missing)}"
+                ))
+        else:
+            users = list(User.objects.filter(id__in=options["ids"]))
+            missing = set(options["ids"]) - {u.id for u in users}
+            if missing:
+                self.stdout.write(self.style.WARNING(
+                    f"IDs no trobats: {', '.join(map(str, missing))}"
+                ))
+
+        if not users:
+            self.stdout.write("Cap usuari per processar.")
+            return
+
+        with transaction.atomic():
+            for user in users:
+                old_uid = get_stream_user_id(user)
+                user.chat_stream_id_version = (user.chat_stream_id_version or 1) + 1
+                user.save(update_fields=["chat_stream_id_version"])
+                new_uid = get_stream_user_id(user)
+                self.stdout.write(self.style.SUCCESS(
+                    f"  {user.email} (id={user.id}): {old_uid} -> {new_uid}"
+                ))
+
+        self.stdout.write(self.style.SUCCESS(
+            f"\nBumped {len(users)} usuari(s). Recorda dir-los que tanquin i "
+            f"reobrin sessió perquè es reconnectin amb el nou user_id."
+        ))
+
+    def _detect_broken_users(self):
+        """Detecta usuaris Django amb el seu actual user_id tombstoned a GetStream."""
+        client = get_stream_client()
+        broken = []
+        for user in User.objects.iterator():
+            uid = get_stream_user_id(user)
+            try:
+                resp = client.query_users({"id": uid})
+                stream_user = (resp.get("users") or [None])[0]
+                if stream_user and stream_user.get("deleted_at"):
+                    broken.append(user)
+                    self.stdout.write(f"  detectat tombstoned: {user.email} ({uid})")
+            except Exception as exc:
+                self.stdout.write(self.style.WARNING(
+                    f"  no s'ha pogut consultar {uid}: {exc}"
+                ))
+        return broken

--- a/backend/apps/chat/services.py
+++ b/backend/apps/chat/services.py
@@ -29,8 +29,18 @@ def get_stream_client() -> StreamChat:
 
 
 def get_stream_user_id(user) -> str:
-    """Retorna un identificador estable per a GetStream basat en l'ID de Django."""
-    return f"user_{user.id}"
+    """Retorna un identificador estable per a GetStream basat en l'ID de Django.
+
+    Per defecte (`chat_stream_id_version == 1`), retorna "user_{id}". Si el
+    user_id antic queda tombstoned a GetStream (per un hard-delete irreversible),
+    es pot bumpar `chat_stream_id_version` perquè aquesta funció emeti
+    "user_{id}_v{N}" — un identificador nou que GetStream tracta com un
+    usuari verge.
+    """
+    version = getattr(user, "chat_stream_id_version", 1) or 1
+    if version <= 1:
+        return f"user_{user.id}"
+    return f"user_{user.id}_v{version}"
 
 
 def sync_user_to_stream(client: StreamChat, user) -> None:
@@ -62,9 +72,29 @@ def sync_user_to_stream(client: StreamChat, user) -> None:
             client.reactivate_user(stream_uid)
             client.upsert_user(user_data)
         except Exception:
-            # User was hard-deleted in GetStream and cannot be restored.
-            # Log and continue — sync is best-effort.
-            logger.warning("No s'ha pogut restaurar l'usuari %s a GetStream (hard-deleted).", stream_uid)
+            # Hard-deleted i no recuperable: bumpa la versió del user_id i
+            # reintenta amb un identificador verge. Així evitem haver de
+            # córrer `bump_stream_user_id` manualment cada vegada que un
+            # usuari nou xoca amb un user_id tombstoned per tests anteriors.
+            try:
+                current_version = (
+                    getattr(user, "chat_stream_id_version", 1) or 1
+                )
+                user.chat_stream_id_version = current_version + 1
+                user.save(update_fields=["chat_stream_id_version"])
+                new_uid = get_stream_user_id(user)
+                user_data["id"] = new_uid
+                client.upsert_user(user_data)
+                logger.info(
+                    "User %s estava tombstoned a GetStream; bumpat a versió "
+                    "%d (nou ID: %s).",
+                    stream_uid, user.chat_stream_id_version, new_uid,
+                )
+            except Exception:
+                logger.warning(
+                    "No s'ha pogut restaurar ni recrear l'usuari %s a GetStream.",
+                    stream_uid, exc_info=True,
+                )
 
 
 def create_stream_token_for_user(user) -> str:
@@ -76,7 +106,6 @@ def create_stream_token_for_user(user) -> str:
     mai surt del backend.
     """
     client = get_stream_client()
-    stream_uid = get_stream_user_id(user)
 
     try:
         sync_user_to_stream(client, user)
@@ -84,6 +113,13 @@ def create_stream_token_for_user(user) -> str:
         logger.warning(
             "No s'ha pogut sincronitzar l'usuari %s a GetStream.", user.id, exc_info=True
         )
+
+    # IMPORTANT: agafem l'ID DESPRÉS de la sync. Si l'usuari tenia un user_id
+    # tombstoned, `sync_user_to_stream` haurà bumpat `chat_stream_id_version`
+    # i ara `get_stream_user_id` retorna l'ID nou (p. ex. `user_X_v2`). Si
+    # generéssim el token abans de la sync, el client rebria un token amb
+    # l'ID mort i el WebSocket de GetStream rebutjaria la connexió.
+    stream_uid = get_stream_user_id(user)
 
     expiration_seconds = int(getattr(settings, "STREAM_TOKEN_EXPIRATION_SECONDS", 3600))
     return client.create_token(stream_uid, expiration=int(time.time()) + expiration_seconds)
@@ -290,9 +326,12 @@ def get_or_create_channels_for_user(user) -> list[dict[str, Any]]:
     4. Retorna la llista de descriptors de canals.
     """
     client = get_stream_client()
-    stream_uid = get_stream_user_id(user)
 
     sync_user_to_stream(client, user)
+
+    # Agafem l'ID DESPRÉS de la sync per si l'auto-bump ha canviat la versió.
+    # Si capturéssim abans, afegiríem l'usuari als canals amb l'ID mort.
+    stream_uid = get_stream_user_id(user)
 
     buildings = get_accessible_buildings(user)
     role = getattr(getattr(user, "profile", None), "role", None)

--- a/backend/apps/chat/tests.py
+++ b/backend/apps/chat/tests.py
@@ -142,11 +142,45 @@ class SyncUserToStreamTests(TestCase):
         from apps.chat.services import get_stream_client, sync_user_to_stream
         mock_client = MagicMock()
         mock_sc.return_value = mock_client
+        # Tots els intents fallen (inclou el retry post-bump) → warning final.
         mock_client.upsert_user.side_effect = Exception("User was deleted")
         mock_client.reactivate_user.side_effect = Exception("Cannot reactivate hard-deleted")
         client = get_stream_client()
         sync_user_to_stream(client, self.user)  # no ha de llançar excepció
         mock_logger.warning.assert_called()
+
+    @patch("apps.chat.services.logger")
+    @patch("apps.chat.services.StreamChat")
+    def test_sync_auto_bumps_version_on_tombstone(self, mock_sc, mock_logger):
+        """Si el user_id està tombstoned, bumpa la versió i reintenta amb el
+        nou ID sense intervenció manual (no cal cap script)."""
+        from apps.chat.services import get_stream_client, sync_user_to_stream
+        mock_client = MagicMock()
+        mock_sc.return_value = mock_client
+        # Primer upsert falla ("was deleted"), reactivate també falla
+        # (hard-deleted), el segon upsert (amb ID versionat) té èxit.
+        mock_client.upsert_user.side_effect = [
+            Exception("User was deleted"),
+            None,
+        ]
+        mock_client.reactivate_user.side_effect = Exception("Cannot reactivate")
+
+        self.assertEqual(self.user.chat_stream_id_version, 1)
+
+        client = get_stream_client()
+        sync_user_to_stream(client, self.user)
+
+        # La versió s'ha incrementat persistentment.
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.chat_stream_id_version, 2)
+
+        # El segon upsert s'ha fet amb l'ID versionat nou.
+        self.assertEqual(mock_client.upsert_user.call_count, 2)
+        second_call_args = mock_client.upsert_user.call_args_list[1][0][0]
+        self.assertEqual(second_call_args["id"], f"user_{self.user.id}_v2")
+
+        # Es logga un info (no un warning) perquè la recuperació ha funcionat.
+        mock_logger.info.assert_called()
  
     @patch("apps.chat.services.StreamChat")
     def test_sync_raises_non_deleted_exception(self, mock_sc):
@@ -157,6 +191,36 @@ class SyncUserToStreamTests(TestCase):
         client = get_stream_client()
         with self.assertRaises(Exception):
             sync_user_to_stream(client, self.user)
+
+    @override_settings(
+        STREAM_API_KEY="k",
+        STREAM_API_SECRET="s",
+        STREAM_TOKEN_EXPIRATION_SECONDS=3600,
+    )
+    @patch("apps.chat.services.StreamChat")
+    def test_token_uses_bumped_id_after_tombstone(self, mock_sc):
+        """Regressió: si l'usuari té un user_id tombstoned, el token emès ha
+        d'usar el NOU ID (bumpat), no l'antic. Si no, GetStream rebutja la
+        connexió WebSocket."""
+        from apps.chat.services import create_stream_token_for_user
+        mock_client = MagicMock()
+        mock_sc.return_value = mock_client
+        # Primer upsert falla, reactivate falla, retry amb v2 reïx.
+        mock_client.upsert_user.side_effect = [
+            Exception("User was deleted"),
+            None,
+        ]
+        mock_client.reactivate_user.side_effect = Exception("hard-deleted")
+        mock_client.create_token.return_value = "fake.jwt.token"
+
+        create_stream_token_for_user(self.user)
+
+        # create_token s'ha cridat amb l'ID bumpat (v2), no l'antic.
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.chat_stream_id_version, 2)
+        token_call_args = mock_client.create_token.call_args
+        token_user_id = token_call_args[0][0]
+        self.assertEqual(token_user_id, f"user_{self.user.id}_v2")
  
  
 # ---------------------------------------------------------------------------
@@ -1902,3 +1966,118 @@ class TwinBuildingDirectChatTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("target_edifici_id", response.data["detail"])
+
+
+# ---------------------------------------------------------------------------
+# services.py — get_stream_user_id (chat_stream_id_version branch)
+# ---------------------------------------------------------------------------
+
+class GetStreamUserIdVersionTests(TestCase):
+    """Cobreix la lògica de versionat de user_id introduïda perquè usuaris
+    amb el seu user_id antic tombstoned a GetStream puguin reconnectar amb
+    un identificador nou."""
+
+    def setUp(self):
+        from apps.chat.services import get_stream_user_id
+        self._get = get_stream_user_id
+        self.user = User.objects.create_user(
+            email="versioned@test.com",
+            password="StrongPass123!",
+        )
+
+    def test_default_version_returns_plain_user_id(self):
+        # Version per defecte (1) → format "user_{id}" tradicional.
+        self.assertEqual(self.user.chat_stream_id_version, 1)
+        self.assertEqual(self._get(self.user), f"user_{self.user.id}")
+
+    def test_bumped_version_returns_versioned_user_id(self):
+        # En bumpar la versió, l'id passa a "user_{id}_v{N}".
+        self.user.chat_stream_id_version = 2
+        self.user.save(update_fields=["chat_stream_id_version"])
+        self.assertEqual(self._get(self.user), f"user_{self.user.id}_v2")
+
+        self.user.chat_stream_id_version = 5
+        self.user.save(update_fields=["chat_stream_id_version"])
+        self.assertEqual(self._get(self.user), f"user_{self.user.id}_v5")
+
+    def test_zero_or_none_version_falls_back_to_default(self):
+        # Defensiu: si algú força el camp a 0 (o None per objectes en memòria),
+        # el helper ha de retornar el format per defecte sense petar.
+        self.user.chat_stream_id_version = 0
+        self.user.save(update_fields=["chat_stream_id_version"])
+        self.assertEqual(self._get(self.user), f"user_{self.user.id}")
+
+
+# ---------------------------------------------------------------------------
+# management/commands/bump_stream_user_id
+# ---------------------------------------------------------------------------
+
+class BumpStreamUserIdCommandTests(TestCase):
+    """Cobreix el command que bumpa chat_stream_id_version per a usuaris
+    afectats per un hard-delete a GetStream."""
+
+    def setUp(self):
+        from io import StringIO
+        self._StringIO = StringIO
+        self.user_a = User.objects.create_user(
+            email="bump_a@test.com",
+            password="StrongPass123!",
+        )
+        self.user_b = User.objects.create_user(
+            email="bump_b@test.com",
+            password="StrongPass123!",
+        )
+
+    def _call(self, *args):
+        from django.core.management import call_command
+        out = self._StringIO()
+        call_command("bump_stream_user_id", *args, stdout=out)
+        return out.getvalue()
+
+    def test_bump_by_ids_increments_versions(self):
+        output = self._call("--ids", str(self.user_a.id), str(self.user_b.id))
+        self.user_a.refresh_from_db()
+        self.user_b.refresh_from_db()
+        self.assertEqual(self.user_a.chat_stream_id_version, 2)
+        self.assertEqual(self.user_b.chat_stream_id_version, 2)
+        # El missatge final inclou el nou user_id format versionat.
+        self.assertIn(f"user_{self.user_a.id}_v2", output)
+        self.assertIn(f"user_{self.user_b.id}_v2", output)
+
+    def test_bump_by_emails_increments_versions(self):
+        self._call("--emails", self.user_a.email)
+        self.user_a.refresh_from_db()
+        self.user_b.refresh_from_db()
+        self.assertEqual(self.user_a.chat_stream_id_version, 2)
+        # L'altre usuari no s'ha tocat.
+        self.assertEqual(self.user_b.chat_stream_id_version, 1)
+
+    def test_bump_with_missing_id_warns_and_skips(self):
+        missing_id = 999999
+        output = self._call("--ids", str(self.user_a.id), str(missing_id))
+        self.user_a.refresh_from_db()
+        self.assertEqual(self.user_a.chat_stream_id_version, 2)
+        self.assertIn("no trobats", output)
+        self.assertIn(str(missing_id), output)
+
+    def test_bump_with_missing_email_warns_and_skips(self):
+        output = self._call("--emails", self.user_a.email, "ghost@test.com")
+        self.user_a.refresh_from_db()
+        self.assertEqual(self.user_a.chat_stream_id_version, 2)
+        self.assertIn("no trobats", output)
+        self.assertIn("ghost@test.com", output)
+
+    def test_bump_with_no_matching_users_prints_nothing_to_process(self):
+        output = self._call("--ids", "999998", "999999")
+        self.user_a.refresh_from_db()
+        self.user_b.refresh_from_db()
+        # No s'ha tocat ningú.
+        self.assertEqual(self.user_a.chat_stream_id_version, 1)
+        self.assertEqual(self.user_b.chat_stream_id_version, 1)
+        self.assertIn("Cap usuari per processar", output)
+
+    def test_bump_twice_keeps_incrementing(self):
+        self._call("--ids", str(self.user_a.id))
+        self._call("--ids", str(self.user_a.id))
+        self.user_a.refresh_from_db()
+        self.assertEqual(self.user_a.chat_stream_id_version, 3)


### PR DESCRIPTION
Aquesta PR porta a main només el delta real que faltava respecte Desenvolupament després de la promoció principal.

Canvis:
- Afegeix la migració per versionar l’identificador d’usuari de Stream Chat.
- Sincronitza els canvis finals del model d’usuari relacionats amb Stream.
- Afegeix la comanda per actualitzar/bump dels identificadors d’usuari de Stream.
- Sincronitza els ajustos finals del servei de xat.
- Actualitza els tests associats al xat.
- Afegeix la comanda de seed de dades demo.

Motiu:
La PR directa Desenvolupament -> main arrossega molts commits per diferències d’historial, tot i que main ja conté gairebé tot el contingut. Aquesta branca parteix de main i aplica només els fitxers que realment difereixen.

No requereix rebase ni modificar la branca protegida Desenvolupament.